### PR TITLE
Fix auditwheel purelib warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,17 @@
 #!/usr/bin/env python3
 
 from setuptools import setup
+from setuptools.command.install import install
 from setuptools.dist import Distribution
+
+
+class InstallPlatlib(install):
+  """Fix auditwheel error, https://github.com/google/or-tools/issues/616"""
+
+  def finalize_options(self) -> None:
+    install.finalize_options(self)
+    if self.distribution.has_ext_modules():
+      self.install_lib = self.install_platlib
 
 
 class BinaryDistribution(Distribution):
@@ -14,4 +24,4 @@ class BinaryDistribution(Distribution):
 
 
 if __name__ == '__main__':
-  setup(distclass=BinaryDistribution)
+  setup(distclass=BinaryDistribution, cmdclass={'install': InstallPlatlib})


### PR DESCRIPTION
Current wheel with shared library fails to be repaired by auditwheel.

Solution adopted from
https://github.com/google/or-tools/issues/616