### PR TITLE
use pre-calculated 256*256 mapping table to speedup maxpool and grayscale wrapper

### DIFF
--- a/envpool/atari/atari_env.h
+++ b/envpool/atari/atari_env.h
@@ -201,7 +201,8 @@ class AtariEnv : public Env<AtariEnvSpec> {
                kRawSize);
       }
     }
-    PushStack(false, skip_id == 0);  // push the maxpool outcome to the stack_buf
+    PushStack(false,
+              skip_id == 0);  // push the maxpool outcome to the stack_buf
     ++elapsed_step_;
     if (reward_clip_) {
       if (reward > 0) {

--- a/envpool/atari/atari_env.h
+++ b/envpool/atari/atari_env.h
@@ -46,8 +46,6 @@ std::string GetRomPath(std::string base_path, std::string task) {
   return ss.str();
 }
 
-typedef Spec<uint8_t> FrameSpec;
-
 class AtariEnvFns {
  public:
   static decltype(auto) DefaultConfig() {
@@ -78,6 +76,7 @@ class AtariEnvFns {
 };
 
 typedef class EnvSpec<AtariEnvFns> AtariEnvSpec;
+typedef Spec<uint8_t> FrameSpec;
 
 class AtariEnv : public Env<AtariEnvSpec> {
  protected:
@@ -211,8 +210,8 @@ class AtariEnv : public Env<AtariEnvSpec> {
                kRawSize);
       }
     }
-    PushStack(false,
-              skip_id == 0);  // push the maxpool outcome to the stack_buf
+    // push the maxpool outcome to the stack_buf
+    PushStack(false, skip_id == 0);
     ++elapsed_step_;
     if (reward_clip_) {
       if (reward > 0) {


### PR DESCRIPTION
release v0.4.1 can only run 38k FPS in my laptop (introduced by #13) but this optimization can achieve 50k FPS (same as v0.4.0).