### PR TITLE
modify internal API to be more user-friendly

### DIFF
--- a/envpool/atari/api_test.py
+++ b/envpool/atari/api_test.py
@@ -54,6 +54,25 @@ class _SpecTest(absltest.TestCase):
       self.assertIsInstance(gym_act_space, gym.spaces.Discrete)
       self.assertEqual(gym_act_space.n, action_num)
 
+  def test_seed_warning(self) -> None:
+    num_envs = 4
+    config = AtariEnvSpec.gen_config(task="pong", num_envs=num_envs)
+    spec = AtariEnvSpec(config)
+    env = AtariDMEnvPool(spec)
+    with self.assertWarns(UserWarning):
+      env.seed(1)
+    env = AtariGymEnvPool(spec)
+    with self.assertWarns(UserWarning):
+      env.seed()
+
+  def test_invalid_batch_size(self) -> None:
+    num_envs = 4
+    batch_size = 5
+    config = AtariEnvSpec.gen_config(
+      task="pong", num_envs=num_envs, batch_size=batch_size
+    )
+    self.assertRaises(ValueError, AtariEnvSpec, config)
+
 
 class _DMSyncTest(absltest.TestCase):
 

--- a/envpool/atari/atari_env.h
+++ b/envpool/atari/atari_env.h
@@ -64,8 +64,7 @@ class AtariEnvFns {
             {conf["stack_num"_], conf["img_height"_], conf["img_width"_]},
             {0, 255})),
         "discount"_.bind(Spec<float>({-1}, {0.0f, 1.0f})),
-        "info:lives"_.bind(Spec<int>({-1}, {0, 5})),
-        "reward"_.bind(Spec<float>({-1})));
+        "info:lives"_.bind(Spec<int>({-1}, {0, 5})));
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {

--- a/envpool/atari/atari_pretrain_test.py
+++ b/envpool/atari/atari_pretrain_test.py
@@ -78,9 +78,9 @@ class _AtariPretrainTest(absltest.TestCase):
     rew = reward.mean()
     logging.info(f"Mean reward of {task}: {rew}")
     if task.startswith("Pong"):
-      assert rew >= 19
+      assert rew == 20.2
     elif task.startswith("Breakout"):
-      assert rew >= 350
+      assert rew == 362.5
 
   def test_pong(self) -> None:
     model_path = os.path.join("envpool", "atari", "policy-pong.pth")

--- a/envpool/core/env_spec.h
+++ b/envpool/core/env_spec.h
@@ -63,7 +63,7 @@ class EnvSpec {
       ConcatDict(common_config, EnvFns::DefaultConfig());
 
  public:
-  EnvSpec(): EnvSpec(default_config) {}
+  EnvSpec() : EnvSpec(default_config) {}
   explicit EnvSpec(const ConfigValues& conf)
       : config(conf),
         state_spec(ConcatDict(common_state_spec, EnvFns::StateSpec(config))),

--- a/envpool/core/env_spec.h
+++ b/envpool/core/env_spec.h
@@ -34,7 +34,8 @@ auto common_action_spec = MakeDict("env_id"_.bind(Spec<int>({})),
 auto common_state_spec =
     MakeDict("info:env_id"_.bind(Spec<int>({})),
              "info:players.env_id"_.bind(Spec<int>({-1})),
-             "elapsed_step"_.bind(Spec<int>({})), "done"_.bind(Spec<bool>({})));
+             "elapsed_step"_.bind(Spec<int>({})), "done"_.bind(Spec<bool>({})),
+             "reward"_.bind(Spec<float>({-1})));
 
 /**
  * EnvSpec funciton, it constructs the env spec when a Config is passed.
@@ -66,12 +67,26 @@ class EnvSpec {
       : config(default_config),
         state_spec(ConcatDict(common_state_spec, EnvFns::StateSpec(config))),
         action_spec(
-            ConcatDict(common_action_spec, EnvFns::ActionSpec(config))) {}
+            ConcatDict(common_action_spec, EnvFns::ActionSpec(config))) {
+    if (config["batch_size"_] > config["num_envs"_]) {
+      throw std::invalid_argument(
+          "It is required that batch_size <= num_envs, got num_envs = " +
+          std::to_string(config["num_envs"_]) +
+          ", batch_size = " + std::to_string(config["batch_size"_]));
+    }
+  }
   explicit EnvSpec(const ConfigValues& conf)
       : config(conf),
         state_spec(ConcatDict(common_state_spec, EnvFns::StateSpec(config))),
         action_spec(
-            ConcatDict(common_action_spec, EnvFns::ActionSpec(config))) {}
+            ConcatDict(common_action_spec, EnvFns::ActionSpec(config))) {
+    if (config["batch_size"_] > config["num_envs"_]) {
+      throw std::invalid_argument(
+          "It is required that batch_size <= num_envs, got num_envs = " +
+          std::to_string(config["num_envs"_]) +
+          ", batch_size = " + std::to_string(config["batch_size"_]));
+    }
+  }
 };
 
 #endif  // ENVPOOL_CORE_ENV_SPEC_H_

--- a/envpool/core/env_spec.h
+++ b/envpool/core/env_spec.h
@@ -63,18 +63,7 @@ class EnvSpec {
       ConcatDict(common_config, EnvFns::DefaultConfig());
 
  public:
-  EnvSpec()
-      : config(default_config),
-        state_spec(ConcatDict(common_state_spec, EnvFns::StateSpec(config))),
-        action_spec(
-            ConcatDict(common_action_spec, EnvFns::ActionSpec(config))) {
-    if (config["batch_size"_] > config["num_envs"_]) {
-      throw std::invalid_argument(
-          "It is required that batch_size <= num_envs, got num_envs = " +
-          std::to_string(config["num_envs"_]) +
-          ", batch_size = " + std::to_string(config["batch_size"_]));
-    }
-  }
+  EnvSpec(): EnvSpec(default_config) {}
   explicit EnvSpec(const ConfigValues& conf)
       : config(conf),
         state_spec(ConcatDict(common_state_spec, EnvFns::StateSpec(config))),

--- a/envpool/dummy/dummy_envpool.h
+++ b/envpool/dummy/dummy_envpool.h
@@ -74,7 +74,6 @@ class DummyEnvFns {
   template <typename Config>
   static decltype(auto) StateSpec(const Config& conf) {
     return MakeDict("obs"_.bind(Spec<int>({-1, conf["state_num"_]})),
-                    "reward"_.bind(Spec<float>({-1})),
                     "info:players.done"_.bind(Spec<bool>({-1})),
                     "info:players.id"_.bind(
                         Spec<int>({-1}, {0, conf["max_num_players"_]})));

--- a/envpool/python/envpool.py
+++ b/envpool/python/envpool.py
@@ -14,6 +14,7 @@
 """EnvPool Mixin class for meta class definition."""
 
 import pprint
+import warnings
 from abc import ABC
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -87,6 +88,15 @@ class EnvPoolMixin(ABC):
     """Return if this env is in sync mode or async mode."""
     return self.config["batch_size"] > 0 and self.config[
       "num_envs"] != self.config["batch_size"]
+
+  def seed(
+    self: EnvPool, seed: Optional[Union[int, List[int]]] = None
+  ) -> None:
+    """Set the seed for all environments (abandoned)."""
+    warnings.warn(
+      "The `seed` function in envpool is abandoned. "
+      "You can set seed by envpool.make(\"..., seed=seed\") instead."
+    )
 
   def send(
     self: EnvPool,

--- a/envpool/python/protocol.py
+++ b/envpool/python/protocol.py
@@ -173,6 +173,9 @@ class EnvPool(Protocol):
   def action_spec(self) -> Union[dm_env.specs.Array, Tuple]:
     """Dm action spec."""
 
+  def seed(self, seed: Optional[Union[int, List[int]]] = None) -> None:
+    """Set the seed for all environments."""
+
   @property
   def config(self) -> Dict[str, Any]:
     """Envpool config."""


### PR DESCRIPTION
1. add a warning when calling `envpool.seed` function
2. raise ValueError when `batch_size > num_envs`
3. move `reward` to `common_state_spec`