### PR TITLE
Align with gym mujoco options

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,8 @@ build --action_env=BAZEL_LINKLIBS=-l%:libstdc++.a:-lm
 build --action_env=BAZEL_LINKOPTS=-static-libgcc
 build --incompatible_strict_action_env --cxxopt=-std=c++17 --host_cxxopt=-std=c++17 --client_env=BAZEL_CXXOPTS=-std=c++17
 build:release --copt=-g0 --copt=-O3 --copt=-DNDEBUG --copt=-msse --copt=-msse2 --copt=-mmmx
-build:debug --compilation_mode=dbg -s
+build:debug --cxxopt=-DENVPOOL_TEST --compilation_mode=dbg -s
+build:test --cxxopt=-DENVPOOL_TEST
 
 build:clang-tidy --aspects @bazel_clang_tidy//clang_tidy:clang_tidy.bzl%clang_tidy_aspect
 build:clang-tidy --@bazel_clang_tidy//:clang_tidy_config=//:clang_tidy_config

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release PyPI Wheel
 
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
+# on:
+#   push:
+#     branches:
+#       - master
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release PyPI Wheel
 
-on: [push, pull_request]
-# on:
-#   push:
-#     branches:
-#       - master
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   release:

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ release-test1:
 	cd envpool && python3 make_test.py
 
 release-test2:
-	cd examples && python3 env_step.py
+	cd examples && python3 make_env.py && python3 env_step.py
 
 release-test: release-test1 release-test2
 

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ bazel-build: bazel-install
 	cp bazel-bin/setup.runfiles/$(PROJECT_NAME)/dist/*.whl ./dist
 
 bazel-test: bazel-install
-	bazel test --test_output=all $(BAZELOPT) //... --config=release
+	bazel test --test_output=all $(BAZELOPT) //... --config=release --config=test
 
 bazel-clean: bazel-install
 	bazel clean --expunge

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ def get_version() -> str:
 # -- Project information -----------------------------------------------------
 
 project = "EnvPool"
-copyright = "2021, Garena Online Private Limited"
+copyright = "2022, Garena Online Private Limited"
 author = "EnvPool Contributors"
 
 # The full version, including alpha/beta/rc tags

--- a/docs/pages/contributing.rst
+++ b/docs/pages/contributing.rst
@@ -66,6 +66,9 @@ integration; however, you don't want to build other stuff such as OpenCV:
 .. code-block:: bash
 
     bazel test --test_output=all //envpool/mujoco:mujoco_test --config=release
+    # or alternatively
+    cd bazel-bin/envpool/mujoco/mujoco_test.runfiles/envpool/
+    ./envpool/mujoco/mujoco_test
 
 Feel free to customize the command in ``Makefile``!
 

--- a/docs/pages/env.rst
+++ b/docs/pages/env.rst
@@ -389,6 +389,17 @@ Miscellaneous
     has already been defined as ``gen_`` (`link
     <https://github.com/sail-sg/envpool/blob/v0.4.0/envpool/core/env.h#L37>`_).
 
+.. note ::
+
+    ``ENVPOOL_TEST`` is a test-time macro. If you want a piece of C++ code only
+    available during unit test:
+
+    .. code-block:: c++
+
+        #ifdef ENVPOOL_TEST
+            fprintf(stderr, "here");
+        #endif
+
 
 Generate Dynamic Linked .so File and Instantiate in Python
 ----------------------------------------------------------

--- a/docs/pages/interface.rst
+++ b/docs/pages/interface.rst
@@ -1,5 +1,5 @@
-Interface
-=========
+Python Interface
+================
 
 envpool.make
 ------------

--- a/envpool/core/env.h
+++ b/envpool/core/env.h
@@ -38,7 +38,7 @@ class Env {
 
  private:
   StateBufferQueue* sbq_;
-  int order_, elapsed_step_;
+  int order_, current_step_;
   bool is_single_player_;
   StateBuffer::WritableSlice slice_;
   // for parsing single env action from input action batch
@@ -60,7 +60,7 @@ class Env {
         env_id_(env_id),
         seed_(spec.config["seed"_] + env_id),
         gen_(seed_),
-        elapsed_step_(-1),
+        current_step_(-1),
         is_single_player_(max_num_players_ == 1),
         action_specs_(spec.action_spec.template values<ShapeSpec>()),
         is_player_action_(Transform(action_specs_, [](const ShapeSpec& s) {
@@ -147,9 +147,9 @@ class Env {
     sbq_ = sbq;
     order_ = order;
     if (reset) {
-      elapsed_step_ = 0;
+      current_step_ = 0;
     } else {
-      ++elapsed_step_;
+      ++current_step_;
     }
   }
 
@@ -163,7 +163,7 @@ class Env {
     State state(&slice_.arr);
     state["done"_] = IsDone();
     state["info:env_id"_] = env_id_;
-    state["elapsed_step"_] = elapsed_step_;
+    state["elapsed_step"_] = current_step_;
     int* player_env_id(static_cast<int*>(state["info:players.env_id"_].data()));
     for (int i = 0; i < player_num; ++i) {
       player_env_id[i] = env_id_;

--- a/envpool/mujoco/ant.h
+++ b/envpool/mujoco/ant.h
@@ -48,6 +48,10 @@ class AntEnvFns {
     bool no_pos = conf["exclude_current_positions_from_observation"_];
     return MakeDict(
         "obs"_.bind(Spec<mjtNum>({no_pos ? 111 : 113}, {-inf, inf})),
+#ifdef ENVPOOL_TEST
+        "info:qpos0"_.bind(Spec<mjtNum>({15})),
+        "info:qvel0"_.bind(Spec<mjtNum>({14})),
+#endif
         "info:reward_forward"_.bind(Spec<mjtNum>({-1})),
         "info:reward_ctrl"_.bind(Spec<mjtNum>({-1})),
         "info:reward_contact"_.bind(Spec<mjtNum>({-1})),
@@ -56,10 +60,7 @@ class AntEnvFns {
         "info:y_position"_.bind(Spec<mjtNum>({-1})),
         "info:distance_from_origin"_.bind(Spec<mjtNum>({-1})),
         "info:x_velocity"_.bind(Spec<mjtNum>({-1})),
-        "info:y_velocity"_.bind(Spec<mjtNum>({-1})),
-        // TODO(jiayi): remove these two lines for speed
-        "info:qpos0"_.bind(Spec<mjtNum>({15})),
-        "info:qvel0"_.bind(Spec<mjtNum>({14})));
+        "info:y_velocity"_.bind(Spec<mjtNum>({-1})));
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -201,8 +202,10 @@ class AntEnv : public Env<AntEnvSpec>, public MujocoEnv {
         std::sqrt(x_after * x_after + y_after * y_after);
     state["info:x_velocity"_] = xv;
     state["info:y_velocity"_] = yv;
+#ifdef ENVPOOL_TEST
     state["info:qpos0"_].Assign(qpos0_, model_->nq);
     state["info:qvel0"_].Assign(qvel0_, model_->nv);
+#endif
   }
 };
 

--- a/envpool/mujoco/ant.h
+++ b/envpool/mujoco/ant.h
@@ -105,7 +105,7 @@ class AntEnv : public Env<AntEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    current_step_ = 0;
+    elapsed_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0, 0, 0, 0, 0);
   }
@@ -138,8 +138,8 @@ class AntEnv : public Env<AntEnvSpec>, public MujocoEnv {
     // reward and done
     float reward = xv * forward_reward_weight_ + healthy_reward_ - ctrl_cost -
                    contact_cost;
-    ++current_step_;
-    done_ = !IsHealthy() || (current_step_ >= max_episode_steps_);
+    ++elapsed_step_;
+    done_ = !IsHealthy() || (elapsed_step_ >= max_episode_steps_);
     WriteObs(reward, xv, yv, ctrl_cost, contact_cost, x_after, y_after);
   }
 

--- a/envpool/mujoco/ant.h
+++ b/envpool/mujoco/ant.h
@@ -46,19 +46,20 @@ class AntEnvFns {
   static decltype(auto) StateSpec(const Config& conf) {
     mjtNum inf = std::numeric_limits<mjtNum>::infinity();
     bool no_pos = conf["exclude_current_positions_from_observation"_];
-    return MakeDict("obs"_.bind(Spec<mjtNum>({no_pos ? 111 : 113}, {-inf, inf})),
-                    "info:reward_forward"_.bind(Spec<mjtNum>({-1})),
-                    "info:reward_ctrl"_.bind(Spec<mjtNum>({-1})),
-                    "info:reward_contact"_.bind(Spec<mjtNum>({-1})),
-                    "info:reward_survive"_.bind(Spec<mjtNum>({-1})),
-                    "info:x_position"_.bind(Spec<mjtNum>({-1})),
-                    "info:y_position"_.bind(Spec<mjtNum>({-1})),
-                    "info:distance_from_origin"_.bind(Spec<mjtNum>({-1})),
-                    "info:x_velocity"_.bind(Spec<mjtNum>({-1})),
-                    "info:y_velocity"_.bind(Spec<mjtNum>({-1})),
-                    // TODO(jiayi): remove these two lines for speed
-                    "info:qpos0"_.bind(Spec<mjtNum>({15})),
-                    "info:qvel0"_.bind(Spec<mjtNum>({14})));
+    return MakeDict(
+        "obs"_.bind(Spec<mjtNum>({no_pos ? 111 : 113}, {-inf, inf})),
+        "info:reward_forward"_.bind(Spec<mjtNum>({-1})),
+        "info:reward_ctrl"_.bind(Spec<mjtNum>({-1})),
+        "info:reward_contact"_.bind(Spec<mjtNum>({-1})),
+        "info:reward_survive"_.bind(Spec<mjtNum>({-1})),
+        "info:x_position"_.bind(Spec<mjtNum>({-1})),
+        "info:y_position"_.bind(Spec<mjtNum>({-1})),
+        "info:distance_from_origin"_.bind(Spec<mjtNum>({-1})),
+        "info:x_velocity"_.bind(Spec<mjtNum>({-1})),
+        "info:y_velocity"_.bind(Spec<mjtNum>({-1})),
+        // TODO(jiayi): remove these two lines for speed
+        "info:qpos0"_.bind(Spec<mjtNum>({15})),
+        "info:qvel0"_.bind(Spec<mjtNum>({14})));
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -140,10 +141,9 @@ class AntEnv : public Env<AntEnvSpec>, public MujocoEnv {
       x = std::max(contact_force_min_, x);
       contact_cost += contact_cost_weight_ * x * x;
     }
+    // reward and done
     mjtNum healthy_reward =
         terminate_when_unhealthy_ || IsHealthy() ? healthy_reward_ : 0.0;
-
-    // reward and done
     float reward =
         xv * forward_reward_weight_ + healthy_reward - ctrl_cost - contact_cost;
     ++elapsed_step_;

--- a/envpool/mujoco/half_cheetah.h
+++ b/envpool/mujoco/half_cheetah.h
@@ -43,13 +43,14 @@ class HalfCheetahEnvFns {
     mjtNum inf = std::numeric_limits<mjtNum>::infinity();
     bool no_pos = conf["exclude_current_positions_from_observation"_];
     return MakeDict("obs"_.bind(Spec<mjtNum>({no_pos ? 17 : 18}, {-inf, inf})),
+#ifdef ENVPOOL_TEST
+                    "info:qpos0"_.bind(Spec<mjtNum>({9})),
+                    "info:qvel0"_.bind(Spec<mjtNum>({9})),
+#endif
                     "info:reward_run"_.bind(Spec<mjtNum>({-1})),
                     "info:reward_ctrl"_.bind(Spec<mjtNum>({-1})),
                     "info:x_position"_.bind(Spec<mjtNum>({-1})),
-                    "info:x_velocity"_.bind(Spec<mjtNum>({-1})),
-                    // TODO(jiayi): remove these two lines for speed
-                    "info:qpos0"_.bind(Spec<mjtNum>({9})),
-                    "info:qvel0"_.bind(Spec<mjtNum>({9})));
+                    "info:x_velocity"_.bind(Spec<mjtNum>({-1})));
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -135,8 +136,10 @@ class HalfCheetahEnv : public Env<HalfCheetahEnvSpec>, public MujocoEnv {
     state["info:reward_ctrl"_] = -ctrl_cost;
     state["info:x_position"_] = x_after;
     state["info:x_velocity"_] = xv;
+#ifdef ENVPOOL_TEST
     state["info:qpos0"_].Assign(qpos0_, model_->nq);
     state["info:qvel0"_].Assign(qvel0_, model_->nv);
+#endif
   }
 };
 

--- a/envpool/mujoco/half_cheetah.h
+++ b/envpool/mujoco/half_cheetah.h
@@ -88,7 +88,7 @@ class HalfCheetahEnv : public Env<HalfCheetahEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    current_step_ = 0;
+    elapsed_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0, 0);
   }
@@ -110,7 +110,7 @@ class HalfCheetahEnv : public Env<HalfCheetahEnvSpec>, public MujocoEnv {
     mjtNum xv = (x_after - x_before) / dt;
     // reward and done
     float reward = xv * forward_reward_weight_ - ctrl_cost;
-    done_ = (++current_step_ >= max_episode_steps_);
+    done_ = (++elapsed_step_ >= max_episode_steps_);
     WriteObs(reward, xv, ctrl_cost, x_after);
   }
 

--- a/envpool/mujoco/half_cheetah.h
+++ b/envpool/mujoco/half_cheetah.h
@@ -59,35 +59,28 @@ typedef class EnvSpec<HalfCheetahEnvFns> HalfCheetahEnvSpec;
 
 class HalfCheetahEnv : public Env<HalfCheetahEnvSpec>, public MujocoEnv {
  protected:
-  int max_episode_steps_, elapsed_step_;
   mjtNum ctrl_cost_weight_, forward_reward_weight_;
-  std::unique_ptr<mjtNum> qpos0_, qvel0_;  // for align check
   std::uniform_real_distribution<> dist_qpos_;
   std::normal_distribution<> dist_qvel_;
-  bool done_;
 
  public:
   HalfCheetahEnv(const Spec& spec, int env_id)
       : Env<HalfCheetahEnvSpec>(spec, env_id),
         MujocoEnv(spec.config["base_path"_] + "/mujoco/assets/half_cheetah.xml",
-                  spec.config["frame_skip"_], spec.config["post_constraint"_]),
-        max_episode_steps_(spec.config["max_episode_steps"_]),
-        elapsed_step_(max_episode_steps_ + 1),
+                  spec.config["frame_skip"_], spec.config["post_constraint"_],
+                  spec.config["max_episode_steps"_]),
         ctrl_cost_weight_(spec.config["ctrl_cost_weight"_]),
         forward_reward_weight_(spec.config["forward_reward_weight"_]),
-        qpos0_(new mjtNum[model_->nq]),
-        qvel0_(new mjtNum[model_->nv]),
         dist_qpos_(-spec.config["reset_noise_scale"_],
                    spec.config["reset_noise_scale"_]),
-        dist_qvel_(0, spec.config["reset_noise_scale"_]),
-        done_(true) {}
+        dist_qvel_(0, spec.config["reset_noise_scale"_]) {}
 
   void MujocoResetModel() {
     for (int i = 0; i < model_->nq; ++i) {
-      data_->qpos[i] = qpos0_.get()[i] = init_qpos_[i] + dist_qpos_(gen_);
+      data_->qpos[i] = qpos0_[i] = init_qpos_[i] + dist_qpos_(gen_);
     }
     for (int i = 0; i < model_->nv; ++i) {
-      data_->qvel[i] = qvel0_.get()[i] = init_qvel_[i] + dist_qvel_(gen_);
+      data_->qvel[i] = qvel0_[i] = init_qvel_[i] + dist_qvel_(gen_);
     }
   }
 
@@ -95,7 +88,7 @@ class HalfCheetahEnv : public Env<HalfCheetahEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    elapsed_step_ = 0;
+    current_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0, 0);
   }
@@ -117,7 +110,7 @@ class HalfCheetahEnv : public Env<HalfCheetahEnvSpec>, public MujocoEnv {
     mjtNum xv = (x_after - x_before) / dt;
     // reward and done
     float reward = xv * forward_reward_weight_ - ctrl_cost;
-    done_ = (++elapsed_step_ >= max_episode_steps_);
+    done_ = (++current_step_ >= max_episode_steps_);
     WriteObs(reward, xv, ctrl_cost, x_after);
   }
 
@@ -138,8 +131,8 @@ class HalfCheetahEnv : public Env<HalfCheetahEnvSpec>, public MujocoEnv {
     state["info:reward_ctrl"_] = -ctrl_cost;
     state["info:x_position"_] = x_after;
     state["info:x_velocity"_] = xv;
-    state["info:qpos0"_].Assign(qpos0_.get(), model_->nq);
-    state["info:qvel0"_].Assign(qvel0_.get(), model_->nv);
+    state["info:qpos0"_].Assign(qpos0_, model_->nq);
+    state["info:qvel0"_].Assign(qvel0_, model_->nv);
   }
 };
 

--- a/envpool/mujoco/half_cheetah.h
+++ b/envpool/mujoco/half_cheetah.h
@@ -34,13 +34,15 @@ class HalfCheetahEnvFns {
     return MakeDict(
         "max_episode_steps"_.bind(1000), "reward_threshold"_.bind(4800.0),
         "frame_skip"_.bind(5), "post_constraint"_.bind(true),
+        "exclude_current_positions_from_observation"_.bind(true),
         "ctrl_cost_weight"_.bind(0.1), "forward_reward_weight"_.bind(1.0),
         "reset_noise_scale"_.bind(0.1));
   }
   template <typename Config>
   static decltype(auto) StateSpec(const Config& conf) {
     mjtNum inf = std::numeric_limits<mjtNum>::infinity();
-    return MakeDict("obs"_.bind(Spec<mjtNum>({17}, {-inf, inf})),
+    bool no_pos = conf["exclude_current_positions_from_observation"_];
+    return MakeDict("obs"_.bind(Spec<mjtNum>({no_pos ? 17 : 18}, {-inf, inf})),
                     "info:reward_run"_.bind(Spec<mjtNum>({-1})),
                     "info:reward_ctrl"_.bind(Spec<mjtNum>({-1})),
                     "info:x_position"_.bind(Spec<mjtNum>({-1})),
@@ -59,6 +61,7 @@ typedef class EnvSpec<HalfCheetahEnvFns> HalfCheetahEnvSpec;
 
 class HalfCheetahEnv : public Env<HalfCheetahEnvSpec>, public MujocoEnv {
  protected:
+  bool no_pos_;
   mjtNum ctrl_cost_weight_, forward_reward_weight_;
   std::uniform_real_distribution<> dist_qpos_;
   std::normal_distribution<> dist_qvel_;
@@ -69,6 +72,7 @@ class HalfCheetahEnv : public Env<HalfCheetahEnvSpec>, public MujocoEnv {
         MujocoEnv(spec.config["base_path"_] + "/mujoco/assets/half_cheetah.xml",
                   spec.config["frame_skip"_], spec.config["post_constraint"_],
                   spec.config["max_episode_steps"_]),
+        no_pos_(spec.config["exclude_current_positions_from_observation"_]),
         ctrl_cost_weight_(spec.config["ctrl_cost_weight"_]),
         forward_reward_weight_(spec.config["forward_reward_weight"_]),
         dist_qpos_(-spec.config["reset_noise_scale"_],
@@ -120,7 +124,7 @@ class HalfCheetahEnv : public Env<HalfCheetahEnvSpec>, public MujocoEnv {
     state["reward"_] = reward;
     // obs
     mjtNum* obs = static_cast<mjtNum*>(state["obs"_].data());
-    for (int i = 1; i < model_->nq; ++i) {
+    for (int i = no_pos_ ? 1 : 0; i < model_->nq; ++i) {
       *(obs++) = data_->qpos[i];
     }
     for (int i = 0; i < model_->nv; ++i) {

--- a/envpool/mujoco/hopper.h
+++ b/envpool/mujoco/hopper.h
@@ -100,7 +100,7 @@ class HopperEnv : public Env<HopperEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    current_step_ = 0;
+    elapsed_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0);
   }
@@ -122,8 +122,8 @@ class HopperEnv : public Env<HopperEnvSpec>, public MujocoEnv {
     mjtNum xv = (x_after - x_before) / dt;
     // reward and done
     float reward = xv * forward_reward_weight_ + healthy_reward_ - ctrl_cost;
-    ++current_step_;
-    done_ = !IsHealthy() || (current_step_ >= max_episode_steps_);
+    ++elapsed_step_;
+    done_ = !IsHealthy() || (elapsed_step_ >= max_episode_steps_);
     WriteObs(reward, xv, x_after);
   }
 

--- a/envpool/mujoco/hopper.h
+++ b/envpool/mujoco/hopper.h
@@ -48,11 +48,12 @@ class HopperEnvFns {
     mjtNum inf = std::numeric_limits<mjtNum>::infinity();
     bool no_pos = conf["exclude_current_positions_from_observation"_];
     return MakeDict("obs"_.bind(Spec<mjtNum>({no_pos ? 11 : 12}, {-inf, inf})),
-                    "info:x_position"_.bind(Spec<mjtNum>({-1})),
-                    "info:x_velocity"_.bind(Spec<mjtNum>({-1})),
-                    // TODO(jiayi): remove these two lines for speed
+#ifdef ENVPOOL_TEST
                     "info:qpos0"_.bind(Spec<mjtNum>({6})),
-                    "info:qvel0"_.bind(Spec<mjtNum>({6})));
+                    "info:qvel0"_.bind(Spec<mjtNum>({6})),
+#endif
+                    "info:x_position"_.bind(Spec<mjtNum>({-1})),
+                    "info:x_velocity"_.bind(Spec<mjtNum>({-1})));
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -175,8 +176,10 @@ class HopperEnv : public Env<HopperEnvSpec>, public MujocoEnv {
     // info
     state["info:x_position"_] = x_after;
     state["info:x_velocity"_] = xv;
+#ifdef ENVPOOL_TEST
     state["info:qpos0"_].Assign(qpos0_, model_->nq);
     state["info:qvel0"_].Assign(qvel0_, model_->nv);
+#endif
   }
 };
 

--- a/envpool/mujoco/humanoid.h
+++ b/envpool/mujoco/humanoid.h
@@ -47,6 +47,10 @@ class HumanoidEnvFns {
     bool no_pos = conf["exclude_current_positions_from_observation"_];
     return MakeDict(
         "obs"_.bind(Spec<mjtNum>({no_pos ? 376 : 378}, {-inf, inf})),
+#ifdef ENVPOOL_TEST
+        "info:qpos0"_.bind(Spec<mjtNum>({24})),
+        "info:qvel0"_.bind(Spec<mjtNum>({23})),
+#endif
         "info:reward_linvel"_.bind(Spec<mjtNum>({-1})),
         "info:reward_quadctrl"_.bind(Spec<mjtNum>({-1})),
         "info:reward_alive"_.bind(Spec<mjtNum>({-1})),
@@ -55,10 +59,7 @@ class HumanoidEnvFns {
         "info:y_position"_.bind(Spec<mjtNum>({-1})),
         "info:distance_from_origin"_.bind(Spec<mjtNum>({-1})),
         "info:x_velocity"_.bind(Spec<mjtNum>({-1})),
-        "info:y_velocity"_.bind(Spec<mjtNum>({-1})),
-        // TODO(jiayi): remove these two lines for speed
-        "info:qpos0"_.bind(Spec<mjtNum>({24})),
-        "info:qvel0"_.bind(Spec<mjtNum>({23})));
+        "info:y_velocity"_.bind(Spec<mjtNum>({-1})));
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -207,8 +208,10 @@ class HumanoidEnv : public Env<HumanoidEnvSpec>, public MujocoEnv {
         std::sqrt(x_after * x_after + y_after * y_after);
     state["info:x_velocity"_] = xv;
     state["info:y_velocity"_] = yv;
+#ifdef ENVPOOL_TEST
     state["info:qpos0"_].Assign(qpos0_, model_->nq);
     state["info:qvel0"_].Assign(qvel0_, model_->nv);
+#endif
   }
 };
 

--- a/envpool/mujoco/humanoid.h
+++ b/envpool/mujoco/humanoid.h
@@ -66,22 +66,18 @@ typedef class EnvSpec<HumanoidEnvFns> HumanoidEnvSpec;
 
 class HumanoidEnv : public Env<HumanoidEnvSpec>, public MujocoEnv {
  protected:
-  int max_episode_steps_, elapsed_step_;
   mjtNum ctrl_cost_weight_, contact_cost_weight_, contact_cost_max_;
   mjtNum forward_reward_weight_, healthy_reward_;
   mjtNum healthy_z_min_, healthy_z_max_;
   mjtNum mass_x_, mass_y_;
-  std::unique_ptr<mjtNum> qpos0_, qvel0_;  // for align check
   std::uniform_real_distribution<> dist_;
-  bool done_;
 
  public:
   HumanoidEnv(const Spec& spec, int env_id)
       : Env<HumanoidEnvSpec>(spec, env_id),
         MujocoEnv(spec.config["base_path"_] + "/mujoco/assets/humanoid.xml",
-                  spec.config["frame_skip"_], spec.config["post_constraint"_]),
-        max_episode_steps_(spec.config["max_episode_steps"_]),
-        elapsed_step_(max_episode_steps_ + 1),
+                  spec.config["frame_skip"_], spec.config["post_constraint"_],
+                  spec.config["max_episode_steps"_]),
         ctrl_cost_weight_(spec.config["ctrl_cost_weight"_]),
         contact_cost_weight_(spec.config["contact_cost_weight"_]),
         contact_cost_max_(spec.config["contact_cost_max"_]),
@@ -91,18 +87,15 @@ class HumanoidEnv : public Env<HumanoidEnvSpec>, public MujocoEnv {
         healthy_z_max_(spec.config["healthy_z_max"_]),
         mass_x_(0),
         mass_y_(0),
-        qpos0_(new mjtNum[model_->nq]),
-        qvel0_(new mjtNum[model_->nv]),
         dist_(-spec.config["reset_noise_scale"_],
-              spec.config["reset_noise_scale"_]),
-        done_(true) {}
+              spec.config["reset_noise_scale"_]) {}
 
   void MujocoResetModel() {
     for (int i = 0; i < model_->nq; ++i) {
-      data_->qpos[i] = qpos0_.get()[i] = init_qpos_[i] + dist_(gen_);
+      data_->qpos[i] = qpos0_[i] = init_qpos_[i] + dist_(gen_);
     }
     for (int i = 0; i < model_->nv; ++i) {
-      data_->qvel[i] = qvel0_.get()[i] = init_qvel_[i] + dist_(gen_);
+      data_->qvel[i] = qvel0_[i] = init_qvel_[i] + dist_(gen_);
     }
   }
 
@@ -110,7 +103,7 @@ class HumanoidEnv : public Env<HumanoidEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    elapsed_step_ = 0;
+    current_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0, 0, 0, 0, 0);
   }
@@ -144,8 +137,8 @@ class HumanoidEnv : public Env<HumanoidEnvSpec>, public MujocoEnv {
     // reward and done
     float reward = xv * forward_reward_weight_ + healthy_reward_ - ctrl_cost -
                    contact_cost;
-    ++elapsed_step_;
-    done_ = !IsHealthy() || (elapsed_step_ >= max_episode_steps_);
+    ++current_step_;
+    done_ = !IsHealthy() || (current_step_ >= max_episode_steps_);
     WriteObs(reward, xv, yv, ctrl_cost, contact_cost, x_after, y_after);
   }
 
@@ -202,8 +195,8 @@ class HumanoidEnv : public Env<HumanoidEnvSpec>, public MujocoEnv {
         std::sqrt(x_after * x_after + y_after * y_after);
     state["info:x_velocity"_] = xv;
     state["info:y_velocity"_] = yv;
-    state["info:qpos0"_].Assign(qpos0_.get(), model_->nq);
-    state["info:qvel0"_].Assign(qvel0_.get(), model_->nv);
+    state["info:qpos0"_].Assign(qpos0_, model_->nq);
+    state["info:qvel0"_].Assign(qvel0_, model_->nv);
   }
 };
 

--- a/envpool/mujoco/humanoid.h
+++ b/envpool/mujoco/humanoid.h
@@ -103,7 +103,7 @@ class HumanoidEnv : public Env<HumanoidEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    current_step_ = 0;
+    elapsed_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0, 0, 0, 0, 0);
   }
@@ -137,8 +137,8 @@ class HumanoidEnv : public Env<HumanoidEnvSpec>, public MujocoEnv {
     // reward and done
     float reward = xv * forward_reward_weight_ + healthy_reward_ - ctrl_cost -
                    contact_cost;
-    ++current_step_;
-    done_ = !IsHealthy() || (current_step_ >= max_episode_steps_);
+    ++elapsed_step_;
+    done_ = !IsHealthy() || (elapsed_step_ >= max_episode_steps_);
     WriteObs(reward, xv, yv, ctrl_cost, contact_cost, x_after, y_after);
   }
 

--- a/envpool/mujoco/humanoid_standup.h
+++ b/envpool/mujoco/humanoid_standup.h
@@ -44,14 +44,15 @@ class HumanoidStandupEnvFns {
     mjtNum inf = std::numeric_limits<mjtNum>::infinity();
     bool no_pos = conf["exclude_current_positions_from_observation"_];
     return MakeDict(
+#ifdef ENVPOOL_TEST
+        "info:qpos0"_.bind(Spec<mjtNum>({24})),
+        "info:qvel0"_.bind(Spec<mjtNum>({23})),
+#endif
         "obs"_.bind(Spec<mjtNum>({no_pos ? 376 : 378}, {-inf, inf})),
         "info:reward_linup"_.bind(Spec<mjtNum>({-1})),
         "info:reward_quadctrl"_.bind(Spec<mjtNum>({-1})),
         "info:reward_alive"_.bind(Spec<mjtNum>({-1})),
-        "info:reward_impact"_.bind(Spec<mjtNum>({-1})),
-        // TODO(jiayi): remove these two lines for speed
-        "info:qpos0"_.bind(Spec<mjtNum>({24})),
-        "info:qvel0"_.bind(Spec<mjtNum>({23})));
+        "info:reward_impact"_.bind(Spec<mjtNum>({-1})));
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -160,8 +161,10 @@ class HumanoidStandupEnv : public Env<HumanoidStandupEnvSpec>,
     state["info:reward_quadctrl"_] = -ctrl_cost;
     state["info:reward_impact"_] = -contact_cost;
     state["info:reward_alive"_] = healthy_reward_;
+#ifdef ENVPOOL_TEST
     state["info:qpos0"_].Assign(qpos0_, model_->nq);
     state["info:qvel0"_].Assign(qvel0_, model_->nv);
+#endif
   }
 };
 

--- a/envpool/mujoco/humanoid_standup.h
+++ b/envpool/mujoco/humanoid_standup.h
@@ -93,7 +93,7 @@ class HumanoidStandupEnv : public Env<HumanoidStandupEnvSpec>,
 
   void Reset() override {
     done_ = false;
-    current_step_ = 0;
+    elapsed_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0, 0);
   }
@@ -121,7 +121,7 @@ class HumanoidStandupEnv : public Env<HumanoidStandupEnvSpec>,
     // reward and done
     float reward = xv * forward_reward_weight_ + healthy_reward_ - ctrl_cost -
                    contact_cost;
-    done_ = (++current_step_ >= max_episode_steps_);
+    done_ = (++elapsed_step_ >= max_episode_steps_);
     WriteObs(reward, xv, ctrl_cost, contact_cost);
   }
 

--- a/envpool/mujoco/inverted_double_pendulum.h
+++ b/envpool/mujoco/inverted_double_pendulum.h
@@ -58,39 +58,32 @@ typedef class EnvSpec<InvertedDoublePendulumEnvFns>
 class InvertedDoublePendulumEnv : public Env<InvertedDoublePendulumEnvSpec>,
                                   public MujocoEnv {
  protected:
-  int max_episode_steps_, elapsed_step_;
   mjtNum healthy_reward_, healthy_z_max_;
   mjtNum observation_min_, observation_max_;
-  std::unique_ptr<mjtNum> qpos0_, qvel0_;  // for align check
   std::uniform_real_distribution<> dist_qpos_;
   std::normal_distribution<> dist_qvel_;
-  bool done_;
 
  public:
   InvertedDoublePendulumEnv(const Spec& spec, int env_id)
       : Env<InvertedDoublePendulumEnvSpec>(spec, env_id),
         MujocoEnv(spec.config["base_path"_] +
                       "/mujoco/assets/inverted_double_pendulum.xml",
-                  spec.config["frame_skip"_], spec.config["post_constraint"_]),
-        max_episode_steps_(spec.config["max_episode_steps"_]),
-        elapsed_step_(max_episode_steps_ + 1),
+                  spec.config["frame_skip"_], spec.config["post_constraint"_],
+                  spec.config["max_episode_steps"_]),
         healthy_reward_(spec.config["healthy_reward"_]),
         healthy_z_max_(spec.config["healthy_z_max"_]),
         observation_min_(spec.config["observation_min"_]),
         observation_max_(spec.config["observation_max"_]),
-        qpos0_(new mjtNum[model_->nq]),
-        qvel0_(new mjtNum[model_->nv]),
         dist_qpos_(-spec.config["reset_noise_scale"_],
                    spec.config["reset_noise_scale"_]),
-        dist_qvel_(0, spec.config["reset_noise_scale"_]),
-        done_(true) {}
+        dist_qvel_(0, spec.config["reset_noise_scale"_]) {}
 
   void MujocoResetModel() {
     for (int i = 0; i < model_->nq; ++i) {
-      data_->qpos[i] = qpos0_.get()[i] = init_qpos_[i] + dist_qpos_(gen_);
+      data_->qpos[i] = qpos0_[i] = init_qpos_[i] + dist_qpos_(gen_);
     }
     for (int i = 0; i < model_->nv; ++i) {
-      data_->qvel[i] = qvel0_.get()[i] = init_qvel_[i] + dist_qvel_(gen_);
+      data_->qvel[i] = qvel0_[i] = init_qvel_[i] + dist_qvel_(gen_);
     }
   }
 
@@ -98,7 +91,7 @@ class InvertedDoublePendulumEnv : public Env<InvertedDoublePendulumEnvSpec>,
 
   void Reset() override {
     done_ = false;
-    elapsed_step_ = 0;
+    current_step_ = 0;
     MujocoReset();
     WriteObs(0.0f);
   }
@@ -117,8 +110,8 @@ class InvertedDoublePendulumEnv : public Env<InvertedDoublePendulumEnvSpec>,
     mjtNum vel_penalty = 1e-3 * v1 * v1 + 5e-3 * v2 * v2;
     // reward and done
     float reward = healthy_reward_ - dist_penalty - vel_penalty;
-    ++elapsed_step_;
-    done_ = !IsHealthy() || (elapsed_step_ >= max_episode_steps_);
+    ++current_step_;
+    done_ = !IsHealthy() || (current_step_ >= max_episode_steps_);
     WriteObs(reward);
   }
 
@@ -148,8 +141,8 @@ class InvertedDoublePendulumEnv : public Env<InvertedDoublePendulumEnvSpec>,
       *(obs++) = x;
     }
     // info
-    state["info:qpos0"_].Assign(qpos0_.get(), model_->nq);
-    state["info:qvel0"_].Assign(qvel0_.get(), model_->nv);
+    state["info:qpos0"_].Assign(qpos0_, model_->nq);
+    state["info:qvel0"_].Assign(qvel0_, model_->nv);
   }
 };
 

--- a/envpool/mujoco/inverted_double_pendulum.h
+++ b/envpool/mujoco/inverted_double_pendulum.h
@@ -91,7 +91,7 @@ class InvertedDoublePendulumEnv : public Env<InvertedDoublePendulumEnvSpec>,
 
   void Reset() override {
     done_ = false;
-    current_step_ = 0;
+    elapsed_step_ = 0;
     MujocoReset();
     WriteObs(0.0f);
   }
@@ -110,8 +110,8 @@ class InvertedDoublePendulumEnv : public Env<InvertedDoublePendulumEnvSpec>,
     mjtNum vel_penalty = 1e-3 * v1 * v1 + 5e-3 * v2 * v2;
     // reward and done
     float reward = healthy_reward_ - dist_penalty - vel_penalty;
-    ++current_step_;
-    done_ = !IsHealthy() || (current_step_ >= max_episode_steps_);
+    ++elapsed_step_;
+    done_ = !IsHealthy() || (elapsed_step_ >= max_episode_steps_);
     WriteObs(reward);
   }
 

--- a/envpool/mujoco/inverted_double_pendulum.h
+++ b/envpool/mujoco/inverted_double_pendulum.h
@@ -41,10 +41,13 @@ class InvertedDoublePendulumEnvFns {
   template <typename Config>
   static decltype(auto) StateSpec(const Config& conf) {
     mjtNum inf = std::numeric_limits<mjtNum>::infinity();
+#ifdef ENVPOOL_TEST
     return MakeDict("obs"_.bind(Spec<mjtNum>({11}, {-inf, inf})),
-                    // TODO(jiayi): remove these two lines for speed
                     "info:qpos0"_.bind(Spec<mjtNum>({3})),
                     "info:qvel0"_.bind(Spec<mjtNum>({3})));
+#else
+    return MakeDict("obs"_.bind(Spec<mjtNum>({11}, {-inf, inf})));
+#endif
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -141,8 +144,10 @@ class InvertedDoublePendulumEnv : public Env<InvertedDoublePendulumEnvSpec>,
       *(obs++) = x;
     }
     // info
+#ifdef ENVPOOL_TEST
     state["info:qpos0"_].Assign(qpos0_, model_->nq);
     state["info:qvel0"_].Assign(qvel0_, model_->nv);
+#endif
   }
 };
 

--- a/envpool/mujoco/inverted_pendulum.h
+++ b/envpool/mujoco/inverted_pendulum.h
@@ -40,10 +40,13 @@ class InvertedPendulumEnvFns {
   template <typename Config>
   static decltype(auto) StateSpec(const Config& conf) {
     mjtNum inf = std::numeric_limits<mjtNum>::infinity();
+#ifdef ENVPOOL_TEST
     return MakeDict("obs"_.bind(Spec<mjtNum>({4}, {-inf, inf})),
-                    // TODO(jiayi): remove these two lines for speed
                     "info:qpos0"_.bind(Spec<mjtNum>({2})),
                     "info:qvel0"_.bind(Spec<mjtNum>({2})));
+#else
+    return MakeDict("obs"_.bind(Spec<mjtNum>({4}, {-inf, inf})));
+#endif
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -130,8 +133,10 @@ class InvertedPendulumEnv : public Env<InvertedPendulumEnvSpec>,
       *(obs++) = data_->qvel[i];
     }
     // info
+#ifdef ENVPOOL_TEST
     state["info:qpos0"_].Assign(qpos0_, model_->nq);
     state["info:qvel0"_].Assign(qvel0_, model_->nv);
+#endif
   }
 };
 

--- a/envpool/mujoco/inverted_pendulum.h
+++ b/envpool/mujoco/inverted_pendulum.h
@@ -56,35 +56,28 @@ typedef class EnvSpec<InvertedPendulumEnvFns> InvertedPendulumEnvSpec;
 class InvertedPendulumEnv : public Env<InvertedPendulumEnvSpec>,
                             public MujocoEnv {
  protected:
-  int max_episode_steps_, elapsed_step_;
   mjtNum healthy_reward_, healthy_z_min_, healthy_z_max_;
-  std::unique_ptr<mjtNum> qpos0_, qvel0_;  // for align check
   std::uniform_real_distribution<> dist_;
-  bool done_;
 
  public:
   InvertedPendulumEnv(const Spec& spec, int env_id)
       : Env<InvertedPendulumEnvSpec>(spec, env_id),
         MujocoEnv(
             spec.config["base_path"_] + "/mujoco/assets/inverted_pendulum.xml",
-            spec.config["frame_skip"_], spec.config["post_constraint"_]),
-        max_episode_steps_(spec.config["max_episode_steps"_]),
-        elapsed_step_(max_episode_steps_ + 1),
+            spec.config["frame_skip"_], spec.config["post_constraint"_],
+            spec.config["max_episode_steps"_]),
         healthy_reward_(spec.config["healthy_reward"_]),
         healthy_z_min_(spec.config["healthy_z_min"_]),
         healthy_z_max_(spec.config["healthy_z_max"_]),
-        qpos0_(new mjtNum[model_->nq]),
-        qvel0_(new mjtNum[model_->nv]),
         dist_(-spec.config["reset_noise_scale"_],
-              spec.config["reset_noise_scale"_]),
-        done_(true) {}
+              spec.config["reset_noise_scale"_]) {}
 
   void MujocoResetModel() {
     for (int i = 0; i < model_->nq; ++i) {
-      data_->qpos[i] = qpos0_.get()[i] = init_qpos_[i] + dist_(gen_);
+      data_->qpos[i] = qpos0_[i] = init_qpos_[i] + dist_(gen_);
     }
     for (int i = 0; i < model_->nv; ++i) {
-      data_->qvel[i] = qvel0_.get()[i] = init_qvel_[i] + dist_(gen_);
+      data_->qvel[i] = qvel0_[i] = init_qvel_[i] + dist_(gen_);
     }
   }
 
@@ -92,7 +85,7 @@ class InvertedPendulumEnv : public Env<InvertedPendulumEnvSpec>,
 
   void Reset() override {
     done_ = false;
-    elapsed_step_ = 0;
+    current_step_ = 0;
     MujocoReset();
     WriteObs(0.0f);
   }
@@ -102,8 +95,8 @@ class InvertedPendulumEnv : public Env<InvertedPendulumEnvSpec>,
     MujocoStep(static_cast<mjtNum*>(action["action"_].data()));
 
     // reward and done
-    ++elapsed_step_;
-    done_ = !IsHealthy() || (elapsed_step_ >= max_episode_steps_);
+    ++current_step_;
+    done_ = !IsHealthy() || (current_step_ >= max_episode_steps_);
     WriteObs(1.0f);
   }
 
@@ -137,8 +130,8 @@ class InvertedPendulumEnv : public Env<InvertedPendulumEnvSpec>,
       *(obs++) = data_->qvel[i];
     }
     // info
-    state["info:qpos0"_].Assign(qpos0_.get(), model_->nq);
-    state["info:qvel0"_].Assign(qvel0_.get(), model_->nv);
+    state["info:qpos0"_].Assign(qpos0_, model_->nq);
+    state["info:qvel0"_].Assign(qvel0_, model_->nv);
   }
 };
 

--- a/envpool/mujoco/inverted_pendulum.h
+++ b/envpool/mujoco/inverted_pendulum.h
@@ -85,7 +85,7 @@ class InvertedPendulumEnv : public Env<InvertedPendulumEnvSpec>,
 
   void Reset() override {
     done_ = false;
-    current_step_ = 0;
+    elapsed_step_ = 0;
     MujocoReset();
     WriteObs(0.0f);
   }
@@ -95,8 +95,8 @@ class InvertedPendulumEnv : public Env<InvertedPendulumEnvSpec>,
     MujocoStep(static_cast<mjtNum*>(action["action"_].data()));
 
     // reward and done
-    ++current_step_;
-    done_ = !IsHealthy() || (current_step_ >= max_episode_steps_);
+    ++elapsed_step_;
+    done_ = !IsHealthy() || (elapsed_step_ >= max_episode_steps_);
     WriteObs(1.0f);
   }
 

--- a/envpool/mujoco/mujoco_env.h
+++ b/envpool/mujoco/mujoco_env.h
@@ -33,7 +33,7 @@ class MujocoEnv {
   mjtNum *qpos0_, *qvel0_;  // for align check
   int frame_skip_;
   bool post_constraint_;
-  int max_episode_steps_, current_step_;
+  int max_episode_steps_, elapsed_step_;
   bool done_;
 
  public:
@@ -48,7 +48,7 @@ class MujocoEnv {
         frame_skip_(frame_skip),
         post_constraint_(post_constraint),
         max_episode_steps_(max_episode_steps),
-        current_step_(max_episode_steps + 1),
+        elapsed_step_(max_episode_steps + 1),
         done_(true) {
     memcpy(init_qpos_, data_->qpos, sizeof(mjtNum) * model_->nq);
     memcpy(init_qvel_, data_->qvel, sizeof(mjtNum) * model_->nv);

--- a/envpool/mujoco/mujoco_test.py
+++ b/envpool/mujoco/mujoco_test.py
@@ -130,6 +130,21 @@ class _MujocoEnvPoolTest(absltest.TestCase):
     env1 = AntGymEnvPool(AntEnvSpec(AntEnvSpec.gen_config()))
     self.run_space_check(env0, env1)
     self.run_align_check(env0, env1)
+    env0 = mjc_mwe.AntEnv(
+      terminate_when_unhealthy=False,
+      exclude_current_positions_from_observation=False,
+    )
+    env1 = AntGymEnvPool(
+      AntEnvSpec(
+        AntEnvSpec.gen_config(
+          terminate_when_unhealthy=False,
+          exclude_current_positions_from_observation=False,
+          max_episode_steps=100,
+        )
+      )
+    )
+    self.run_space_check(env0, env1)
+    self.run_align_check(env0, env1, no_time_limit=True)
     self.run_deterministic_check(AntEnvSpec, AntGymEnvPool)
 
   def test_half_cheetah(self) -> None:

--- a/envpool/mujoco/mujoco_test.py
+++ b/envpool/mujoco/mujoco_test.py
@@ -154,6 +154,17 @@ class _MujocoEnvPoolTest(absltest.TestCase):
     )
     self.run_space_check(env0, env1)
     self.run_align_check(env0, env1, no_time_limit=True)
+    env0 = mjc_mwe.HalfCheetahEnv(
+      exclude_current_positions_from_observation=True
+    )
+    env1 = HalfCheetahGymEnvPool(
+      HalfCheetahEnvSpec(
+        HalfCheetahEnvSpec.gen_config(
+          exclude_current_positions_from_observation=True
+        )
+      )
+    )
+    self.run_space_check(env0, env1)
     self.run_deterministic_check(HalfCheetahEnvSpec, HalfCheetahGymEnvPool)
 
   def test_hopper(self) -> None:
@@ -161,6 +172,20 @@ class _MujocoEnvPoolTest(absltest.TestCase):
     env1 = HopperGymEnvPool(HopperEnvSpec(HopperEnvSpec.gen_config()))
     self.run_space_check(env0, env1)
     self.run_align_check(env0, env1)
+    env0 = mjc_mwe.HopperEnv(
+      terminate_when_unhealthy=False,
+      exclude_current_positions_from_observation=False,
+    )
+    env1 = HopperGymEnvPool(
+      HopperEnvSpec(
+        HopperEnvSpec.gen_config(
+          terminate_when_unhealthy=False,
+          exclude_current_positions_from_observation=False,
+        )
+      )
+    )
+    self.run_space_check(env0, env1)
+    self.run_align_check(env0, env1, no_time_limit=True)
     self.run_deterministic_check(HopperEnvSpec, HopperGymEnvPool)
 
   def test_humanoid(self) -> None:
@@ -168,6 +193,20 @@ class _MujocoEnvPoolTest(absltest.TestCase):
     env1 = HumanoidGymEnvPool(HumanoidEnvSpec(HumanoidEnvSpec.gen_config()))
     self.run_space_check(env0, env1)
     self.run_align_check(env0, env1)
+    env0 = mjc_mwe.HumanoidEnv(
+      terminate_when_unhealthy=False,
+      exclude_current_positions_from_observation=False,
+    )
+    env1 = HumanoidGymEnvPool(
+      HumanoidEnvSpec(
+        HumanoidEnvSpec.gen_config(
+          terminate_when_unhealthy=False,
+          exclude_current_positions_from_observation=False,
+        )
+      )
+    )
+    self.run_space_check(env0, env1)
+    self.run_align_check(env0, env1, no_time_limit=True)
     self.run_deterministic_check(HumanoidEnvSpec, HumanoidGymEnvPool)
 
   def test_humanoid_standup(self) -> None:
@@ -224,11 +263,35 @@ class _MujocoEnvPoolTest(absltest.TestCase):
     env1 = SwimmerGymEnvPool(SwimmerEnvSpec(SwimmerEnvSpec.gen_config()))
     self.run_space_check(env0, env1)
     self.run_align_check(env0, env1, no_time_limit=True)
+    env0 = mjc_mwe.SwimmerEnv(exclude_current_positions_from_observation=False)
+    env1 = SwimmerGymEnvPool(
+      SwimmerEnvSpec(
+        SwimmerEnvSpec.gen_config(
+          exclude_current_positions_from_observation=False
+        )
+      )
+    )
+    self.run_space_check(env0, env1)
     self.run_deterministic_check(SwimmerEnvSpec, SwimmerGymEnvPool)
 
   def test_walker2d(self) -> None:
     env0 = mjc_mwe.Walker2dEnv()
     env1 = Walker2dGymEnvPool(Walker2dEnvSpec(Walker2dEnvSpec.gen_config()))
+    self.run_space_check(env0, env1)
+    self.run_align_check(env0, env1)
+    env0 = mjc_mwe.Walker2dEnv(
+      terminate_when_unhealthy=False,
+      exclude_current_positions_from_observation=False,
+    )
+    env1 = Walker2dGymEnvPool(
+      Walker2dEnvSpec(
+        Walker2dEnvSpec.gen_config(
+          terminate_when_unhealthy=False,
+          exclude_current_positions_from_observation=False,
+          max_episode_steps=100,
+        )
+      )
+    )
     self.run_space_check(env0, env1)
     self.run_align_check(env0, env1, no_time_limit=True)
     self.run_deterministic_check(Walker2dEnvSpec, Walker2dGymEnvPool)

--- a/envpool/mujoco/pusher.h
+++ b/envpool/mujoco/pusher.h
@@ -105,7 +105,7 @@ class PusherEnv : public Env<PusherEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    current_step_ = 0;
+    elapsed_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0);
   }
@@ -127,7 +127,7 @@ class PusherEnv : public Env<PusherEnvSpec>, public MujocoEnv {
     float reward = -ctrl_cost * ctrl_cost_weight_ -
                    dist_cost * dist_cost_weight_ -
                    near_cost * near_cost_weight_;
-    done_ = (++current_step_ >= max_episode_steps_);
+    done_ = (++elapsed_step_ >= max_episode_steps_);
     WriteObs(reward, ctrl_cost, dist_cost);
   }
 

--- a/envpool/mujoco/pusher.h
+++ b/envpool/mujoco/pusher.h
@@ -44,11 +44,12 @@ class PusherEnvFns {
   static decltype(auto) StateSpec(const Config& conf) {
     mjtNum inf = std::numeric_limits<mjtNum>::infinity();
     return MakeDict("obs"_.bind(Spec<mjtNum>({23}, {-inf, inf})),
-                    "info:reward_dist"_.bind(Spec<mjtNum>({-1})),
-                    "info:reward_ctrl"_.bind(Spec<mjtNum>({-1})),
-                    // TODO(jiayi): remove these two lines for speed
+#ifdef ENVPOOL_TEST
                     "info:qpos0"_.bind(Spec<mjtNum>({11})),
-                    "info:qvel0"_.bind(Spec<mjtNum>({11})));
+                    "info:qvel0"_.bind(Spec<mjtNum>({11})),
+#endif
+                    "info:reward_dist"_.bind(Spec<mjtNum>({-1})),
+                    "info:reward_ctrl"_.bind(Spec<mjtNum>({-1})));
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -156,8 +157,10 @@ class PusherEnv : public Env<PusherEnvSpec>, public MujocoEnv {
     // info
     state["info:reward_dist"_] = -dist_cost;
     state["info:reward_ctrl"_] = -ctrl_cost;
+#ifdef ENVPOOL_TEST
     state["info:qpos0"_].Assign(qpos0_, model_->nq);
     state["info:qvel0"_].Assign(qvel0_, model_->nv);
+#endif
   }
 };
 

--- a/envpool/mujoco/reacher.h
+++ b/envpool/mujoco/reacher.h
@@ -42,11 +42,12 @@ class ReacherEnvFns {
   static decltype(auto) StateSpec(const Config& conf) {
     mjtNum inf = std::numeric_limits<mjtNum>::infinity();
     return MakeDict("obs"_.bind(Spec<mjtNum>({11}, {-inf, inf})),
-                    "info:reward_dist"_.bind(Spec<mjtNum>({-1})),
-                    "info:reward_ctrl"_.bind(Spec<mjtNum>({-1})),
-                    // TODO(jiayi): remove these two lines for speed
+#ifdef ENVPOOL_TEST
                     "info:qpos0"_.bind(Spec<mjtNum>({4})),
-                    "info:qvel0"_.bind(Spec<mjtNum>({4})));
+                    "info:qvel0"_.bind(Spec<mjtNum>({4})),
+#endif
+                    "info:reward_dist"_.bind(Spec<mjtNum>({-1})),
+                    "info:reward_ctrl"_.bind(Spec<mjtNum>({-1})));
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -156,8 +157,10 @@ class ReacherEnv : public Env<ReacherEnvSpec>, public MujocoEnv {
     // info
     state["info:reward_dist"_] = -dist_cost;
     state["info:reward_ctrl"_] = -ctrl_cost;
+#ifdef ENVPOOL_TEST
     state["info:qpos0"_].Assign(qpos0_, model_->nq);
     state["info:qvel0"_].Assign(qvel0_, model_->nv);
+#endif
   }
 };
 

--- a/envpool/mujoco/reacher.h
+++ b/envpool/mujoco/reacher.h
@@ -100,7 +100,7 @@ class ReacherEnv : public Env<ReacherEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    current_step_ = 0;
+    elapsed_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0);
   }
@@ -123,7 +123,7 @@ class ReacherEnv : public Env<ReacherEnvSpec>, public MujocoEnv {
 
     // reward and done
     float reward = -dist_cost - ctrl_cost;
-    done_ = (++current_step_ >= max_episode_steps_);
+    done_ = (++elapsed_step_ >= max_episode_steps_);
     WriteObs(reward, ctrl_cost, dist_cost);
   }
 

--- a/envpool/mujoco/reacher.h
+++ b/envpool/mujoco/reacher.h
@@ -58,47 +58,40 @@ typedef class EnvSpec<ReacherEnvFns> ReacherEnvSpec;
 
 class ReacherEnv : public Env<ReacherEnvSpec>, public MujocoEnv {
  protected:
-  int max_episode_steps_, elapsed_step_;
   mjtNum ctrl_cost_weight_, dist_cost_weight_;
   mjtNum reset_goal_scale_, dist_x_, dist_y_, dist_z_;
-  std::unique_ptr<mjtNum> qpos0_, qvel0_;  // for align check
   std::uniform_real_distribution<> dist_qpos_, dist_qvel_, dist_goal_;
-  bool done_;
 
  public:
   ReacherEnv(const Spec& spec, int env_id)
       : Env<ReacherEnvSpec>(spec, env_id),
         MujocoEnv(spec.config["base_path"_] + "/mujoco/assets/reacher.xml",
-                  spec.config["frame_skip"_], spec.config["post_constraint"_]),
-        max_episode_steps_(spec.config["max_episode_steps"_]),
-        elapsed_step_(max_episode_steps_ + 1),
+                  spec.config["frame_skip"_], spec.config["post_constraint"_],
+                  spec.config["max_episode_steps"_]),
         ctrl_cost_weight_(spec.config["ctrl_cost_weight"_]),
         dist_cost_weight_(spec.config["dist_cost_weight"_]),
         reset_goal_scale_(spec.config["reset_goal_scale"_]),
-        qpos0_(new mjtNum[model_->nq]),
-        qvel0_(new mjtNum[model_->nv]),
         dist_qpos_(-spec.config["reset_qpos_scale"_],
                    spec.config["reset_qpos_scale"_]),
         dist_qvel_(-spec.config["reset_qvel_scale"_],
                    spec.config["reset_qvel_scale"_]),
         dist_goal_(-spec.config["reset_goal_scale"_],
-                   spec.config["reset_goal_scale"_]),
-        done_(true) {}
+                   spec.config["reset_goal_scale"_]) {}
 
   void MujocoResetModel() {
     for (int i = 0; i < model_->nq - 2; ++i) {
-      data_->qpos[i] = qpos0_.get()[i] = init_qpos_[i] + dist_qpos_(gen_);
+      data_->qpos[i] = qpos0_[i] = init_qpos_[i] + dist_qpos_(gen_);
     }
     while (1) {
       mjtNum x = dist_goal_(gen_), y = dist_goal_(gen_);
       if (std::sqrt(x * x + y * y) < reset_goal_scale_) {
-        data_->qpos[model_->nq - 2] = qpos0_.get()[model_->nq - 2] = x;
-        data_->qpos[model_->nq - 1] = qpos0_.get()[model_->nq - 1] = y;
+        data_->qpos[model_->nq - 2] = qpos0_[model_->nq - 2] = x;
+        data_->qpos[model_->nq - 1] = qpos0_[model_->nq - 1] = y;
         break;
       }
     }
     for (int i = 0; i < model_->nv; ++i) {
-      data_->qvel[i] = qvel0_.get()[i] =
+      data_->qvel[i] = qvel0_[i] =
           i < model_->nv - 2 ? init_qvel_[i] + dist_qvel_(gen_) : 0.0;
     }
   }
@@ -107,7 +100,7 @@ class ReacherEnv : public Env<ReacherEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    elapsed_step_ = 0;
+    current_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0);
   }
@@ -130,7 +123,7 @@ class ReacherEnv : public Env<ReacherEnvSpec>, public MujocoEnv {
 
     // reward and done
     float reward = -dist_cost - ctrl_cost;
-    done_ = (++elapsed_step_ >= max_episode_steps_);
+    done_ = (++current_step_ >= max_episode_steps_);
     WriteObs(reward, ctrl_cost, dist_cost);
   }
 
@@ -163,8 +156,8 @@ class ReacherEnv : public Env<ReacherEnvSpec>, public MujocoEnv {
     // info
     state["info:reward_dist"_] = -dist_cost;
     state["info:reward_ctrl"_] = -ctrl_cost;
-    state["info:qpos0"_].Assign(qpos0_.get(), model_->nq);
-    state["info:qvel0"_].Assign(qvel0_.get(), model_->nv);
+    state["info:qpos0"_].Assign(qpos0_, model_->nq);
+    state["info:qvel0"_].Assign(qvel0_, model_->nv);
   }
 };
 

--- a/envpool/mujoco/registration.py
+++ b/envpool/mujoco/registration.py
@@ -51,7 +51,6 @@ for task, version, post_constraint in mujoco_envs:
     spec_cls=f"{task}EnvSpec",
     dm_cls=f"{task}DMEnvPool",
     gym_cls=f"{task}GymEnvPool",
-    max_episode_steps=1000,
     base_path=base_path,
     post_constraint=post_constraint,
   )

--- a/envpool/mujoco/swimmer.h
+++ b/envpool/mujoco/swimmer.h
@@ -89,7 +89,7 @@ class SwimmerEnv : public Env<SwimmerEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    current_step_ = 0;
+    elapsed_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0, 0, 0, 0);
   }
@@ -113,7 +113,7 @@ class SwimmerEnv : public Env<SwimmerEnvSpec>, public MujocoEnv {
 
     // reward and done
     float reward = xv * forward_reward_weight_ - ctrl_cost;
-    done_ = (++current_step_ >= max_episode_steps_);
+    done_ = (++elapsed_step_ >= max_episode_steps_);
     WriteObs(reward, xv, yv, ctrl_cost, x_after, y_after);
   }
 

--- a/envpool/mujoco/swimmer.h
+++ b/envpool/mujoco/swimmer.h
@@ -43,16 +43,17 @@ class SwimmerEnvFns {
     mjtNum inf = std::numeric_limits<mjtNum>::infinity();
     bool no_pos = conf["exclude_current_positions_from_observation"_];
     return MakeDict("obs"_.bind(Spec<mjtNum>({no_pos ? 8 : 10}, {-inf, inf})),
+#ifdef ENVPOOL_TEST
+                    "info:qpos0"_.bind(Spec<mjtNum>({5})),
+                    "info:qvel0"_.bind(Spec<mjtNum>({5})),
+#endif
                     "info:reward_fwd"_.bind(Spec<mjtNum>({-1})),
                     "info:reward_ctrl"_.bind(Spec<mjtNum>({-1})),
                     "info:x_position"_.bind(Spec<mjtNum>({-1})),
                     "info:y_position"_.bind(Spec<mjtNum>({-1})),
                     "info:distance_from_origin"_.bind(Spec<mjtNum>({-1})),
                     "info:x_velocity"_.bind(Spec<mjtNum>({-1})),
-                    "info:y_velocity"_.bind(Spec<mjtNum>({-1})),
-                    // TODO(jiayi): remove these two lines for speed
-                    "info:qpos0"_.bind(Spec<mjtNum>({5})),
-                    "info:qvel0"_.bind(Spec<mjtNum>({5})));
+                    "info:y_velocity"_.bind(Spec<mjtNum>({-1})));
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -143,8 +144,10 @@ class SwimmerEnv : public Env<SwimmerEnvSpec>, public MujocoEnv {
         std::sqrt(x_after * x_after + y_after * y_after);
     state["info:x_velocity"_] = xv;
     state["info:y_velocity"_] = yv;
+#ifdef ENVPOOL_TEST
     state["info:qpos0"_].Assign(qpos0_, model_->nq);
     state["info:qvel0"_].Assign(qvel0_, model_->nv);
+#endif
   }
 };
 

--- a/envpool/mujoco/swimmer.h
+++ b/envpool/mujoco/swimmer.h
@@ -62,33 +62,26 @@ typedef class EnvSpec<SwimmerEnvFns> SwimmerEnvSpec;
 
 class SwimmerEnv : public Env<SwimmerEnvSpec>, public MujocoEnv {
  protected:
-  int max_episode_steps_, elapsed_step_;
   mjtNum ctrl_cost_weight_, forward_reward_weight_;
-  std::unique_ptr<mjtNum> qpos0_, qvel0_;  // for align check
   std::uniform_real_distribution<> dist_;
-  bool done_;
 
  public:
   SwimmerEnv(const Spec& spec, int env_id)
       : Env<SwimmerEnvSpec>(spec, env_id),
         MujocoEnv(spec.config["base_path"_] + "/mujoco/assets/swimmer.xml",
-                  spec.config["frame_skip"_], spec.config["post_constraint"_]),
-        max_episode_steps_(spec.config["max_episode_steps"_]),
-        elapsed_step_(max_episode_steps_ + 1),
+                  spec.config["frame_skip"_], spec.config["post_constraint"_],
+                  spec.config["max_episode_steps"_]),
         ctrl_cost_weight_(spec.config["ctrl_cost_weight"_]),
         forward_reward_weight_(spec.config["forward_reward_weight"_]),
-        qpos0_(new mjtNum[model_->nq]),
-        qvel0_(new mjtNum[model_->nv]),
         dist_(-spec.config["reset_noise_scale"_],
-              spec.config["reset_noise_scale"_]),
-        done_(true) {}
+              spec.config["reset_noise_scale"_]) {}
 
   void MujocoResetModel() {
     for (int i = 0; i < model_->nq; ++i) {
-      data_->qpos[i] = qpos0_.get()[i] = init_qpos_[i] + dist_(gen_);
+      data_->qpos[i] = qpos0_[i] = init_qpos_[i] + dist_(gen_);
     }
     for (int i = 0; i < model_->nv; ++i) {
-      data_->qvel[i] = qvel0_.get()[i] = init_qvel_[i] + dist_(gen_);
+      data_->qvel[i] = qvel0_[i] = init_qvel_[i] + dist_(gen_);
     }
   }
 
@@ -96,7 +89,7 @@ class SwimmerEnv : public Env<SwimmerEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    elapsed_step_ = 0;
+    current_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0, 0, 0, 0);
   }
@@ -120,7 +113,7 @@ class SwimmerEnv : public Env<SwimmerEnvSpec>, public MujocoEnv {
 
     // reward and done
     float reward = xv * forward_reward_weight_ - ctrl_cost;
-    done_ = (++elapsed_step_ >= max_episode_steps_);
+    done_ = (++current_step_ >= max_episode_steps_);
     WriteObs(reward, xv, yv, ctrl_cost, x_after, y_after);
   }
 
@@ -146,8 +139,8 @@ class SwimmerEnv : public Env<SwimmerEnvSpec>, public MujocoEnv {
         std::sqrt(x_after * x_after + y_after * y_after);
     state["info:x_velocity"_] = xv;
     state["info:y_velocity"_] = yv;
-    state["info:qpos0"_].Assign(qpos0_.get(), model_->nq);
-    state["info:qvel0"_].Assign(qvel0_.get(), model_->nv);
+    state["info:qpos0"_].Assign(qpos0_, model_->nq);
+    state["info:qvel0"_].Assign(qvel0_, model_->nv);
   }
 };
 

--- a/envpool/mujoco/walker2d.h
+++ b/envpool/mujoco/walker2d.h
@@ -60,22 +60,18 @@ typedef class EnvSpec<Walker2dEnvFns> Walker2dEnvSpec;
 
 class Walker2dEnv : public Env<Walker2dEnvSpec>, public MujocoEnv {
  protected:
-  int max_episode_steps_, elapsed_step_;
   mjtNum ctrl_cost_weight_, forward_reward_weight_;
   mjtNum healthy_reward_, healthy_z_min_, healthy_z_max_;
   mjtNum healthy_angle_min_, healthy_angle_max_;
   mjtNum velocity_min_, velocity_max_;
-  std::unique_ptr<mjtNum> qpos0_, qvel0_;  // for align check
   std::uniform_real_distribution<> dist_;
-  bool done_;
 
  public:
   Walker2dEnv(const Spec& spec, int env_id)
       : Env<Walker2dEnvSpec>(spec, env_id),
         MujocoEnv(spec.config["base_path"_] + "/mujoco/assets/walker2d.xml",
-                  spec.config["frame_skip"_], spec.config["post_constraint"_]),
-        max_episode_steps_(spec.config["max_episode_steps"_]),
-        elapsed_step_(max_episode_steps_ + 1),
+                  spec.config["frame_skip"_], spec.config["post_constraint"_],
+                  spec.config["max_episode_steps"_]),
         ctrl_cost_weight_(spec.config["ctrl_cost_weight"_]),
         forward_reward_weight_(spec.config["forward_reward_weight"_]),
         healthy_reward_(spec.config["healthy_reward"_]),
@@ -85,18 +81,15 @@ class Walker2dEnv : public Env<Walker2dEnvSpec>, public MujocoEnv {
         healthy_angle_max_(spec.config["healthy_angle_max"_]),
         velocity_min_(spec.config["velocity_min"_]),
         velocity_max_(spec.config["velocity_max"_]),
-        qpos0_(new mjtNum[model_->nq]),
-        qvel0_(new mjtNum[model_->nv]),
         dist_(-spec.config["reset_noise_scale"_],
-              spec.config["reset_noise_scale"_]),
-        done_(true) {}
+              spec.config["reset_noise_scale"_]) {}
 
   void MujocoResetModel() {
     for (int i = 0; i < model_->nq; ++i) {
-      data_->qpos[i] = qpos0_.get()[i] = init_qpos_[i] + dist_(gen_);
+      data_->qpos[i] = qpos0_[i] = init_qpos_[i] + dist_(gen_);
     }
     for (int i = 0; i < model_->nv; ++i) {
-      data_->qvel[i] = qvel0_.get()[i] = init_qvel_[i] + dist_(gen_);
+      data_->qvel[i] = qvel0_[i] = init_qvel_[i] + dist_(gen_);
     }
   }
 
@@ -104,7 +97,7 @@ class Walker2dEnv : public Env<Walker2dEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    elapsed_step_ = 0;
+    current_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0);
   }
@@ -126,8 +119,8 @@ class Walker2dEnv : public Env<Walker2dEnvSpec>, public MujocoEnv {
     mjtNum xv = (x_after - x_before) / dt;
     // reward and done
     float reward = xv * forward_reward_weight_ + healthy_reward_ - ctrl_cost;
-    ++elapsed_step_;
-    done_ = !IsHealthy() || (elapsed_step_ >= max_episode_steps_);
+    ++current_step_;
+    done_ = !IsHealthy() || (current_step_ >= max_episode_steps_);
     WriteObs(reward, xv, x_after);
   }
 
@@ -160,8 +153,8 @@ class Walker2dEnv : public Env<Walker2dEnvSpec>, public MujocoEnv {
     // info
     state["info:x_position"_] = x_after;
     state["info:x_velocity"_] = xv;
-    state["info:qpos0"_].Assign(qpos0_.get(), model_->nq);
-    state["info:qvel0"_].Assign(qvel0_.get(), model_->nv);
+    state["info:qpos0"_].Assign(qpos0_, model_->nq);
+    state["info:qvel0"_].Assign(qvel0_, model_->nv);
   }
 };
 

--- a/envpool/mujoco/walker2d.h
+++ b/envpool/mujoco/walker2d.h
@@ -47,11 +47,12 @@ class Walker2dEnvFns {
     mjtNum inf = std::numeric_limits<mjtNum>::infinity();
     bool no_pos = conf["exclude_current_positions_from_observation"_];
     return MakeDict("obs"_.bind(Spec<mjtNum>({no_pos ? 17 : 18}, {-inf, inf})),
-                    "info:x_position"_.bind(Spec<mjtNum>({-1})),
-                    "info:x_velocity"_.bind(Spec<mjtNum>({-1})),
-                    // TODO(jiayi): remove these two lines for speed
+#ifdef ENVPOOL_TEST
                     "info:qpos0"_.bind(Spec<mjtNum>({9})),
-                    "info:qvel0"_.bind(Spec<mjtNum>({9})));
+                    "info:qvel0"_.bind(Spec<mjtNum>({9})),
+#endif
+                    "info:x_position"_.bind(Spec<mjtNum>({-1})),
+                    "info:x_velocity"_.bind(Spec<mjtNum>({-1})));
   }
   template <typename Config>
   static decltype(auto) ActionSpec(const Config& conf) {
@@ -162,8 +163,10 @@ class Walker2dEnv : public Env<Walker2dEnvSpec>, public MujocoEnv {
     // info
     state["info:x_position"_] = x_after;
     state["info:x_velocity"_] = xv;
+#ifdef ENVPOOL_TEST
     state["info:qpos0"_].Assign(qpos0_, model_->nq);
     state["info:qvel0"_].Assign(qvel0_, model_->nv);
+#endif
   }
 };
 

--- a/envpool/mujoco/walker2d.h
+++ b/envpool/mujoco/walker2d.h
@@ -97,7 +97,7 @@ class Walker2dEnv : public Env<Walker2dEnvSpec>, public MujocoEnv {
 
   void Reset() override {
     done_ = false;
-    current_step_ = 0;
+    elapsed_step_ = 0;
     MujocoReset();
     WriteObs(0.0f, 0, 0);
   }
@@ -119,8 +119,8 @@ class Walker2dEnv : public Env<Walker2dEnvSpec>, public MujocoEnv {
     mjtNum xv = (x_after - x_before) / dt;
     // reward and done
     float reward = xv * forward_reward_weight_ + healthy_reward_ - ctrl_cost;
-    ++current_step_;
-    done_ = !IsHealthy() || (current_step_ >= max_episode_steps_);
+    ++elapsed_step_;
+    done_ = !IsHealthy() || (elapsed_step_ >= max_episode_steps_);
     WriteObs(reward, xv, x_after);
   }
 

--- a/examples/make_env.py
+++ b/examples/make_env.py
@@ -58,6 +58,13 @@ def make_spec() -> None:
   assert dm_act_spec.num_values, 6
 
 
+def check_info_optim() -> None:
+  env = envpool.make_gym("Ant-v3")
+  info = env.step(np.array([env.action_space.sample()]), np.array([0]))[-1]
+  assert "qpos0" not in info and "qvel0" not in info
+
+
 if __name__ == "__main__":
   make_env()
   make_spec()
+  check_info_optim()


### PR DESCRIPTION
#59

1. simplify code and fix a bug of max_episode_steps
2. add `terminate_when_unhealthy` and `exclude_current_positions_from_observation` for most of mujoco envs
3. add testing macro `ENVPOOL_TEST`
4. eliminate `info["qpos0"]` and `info["qvel0"]` when generating wheel