### PR TITLE
Support dynamic shaped arrays

### DIFF
--- a/docs/pages/env.rst
+++ b/docs/pages/env.rst
@@ -241,6 +241,15 @@ available to see on the python side:
     In dm_env, keys in Spec that start with either ``obs:`` or ``info:`` will
     be merged under ``timestep.observation``.
 
+.. note ::
+
+    To create a dynamic shape array (which will be converted into a numpy
+    array with object type), you can use ``Spec<Container<...>>``, e.g.:
+
+    .. code-block:: c++
+
+        "info:id_list"_.Bind(Spec<int>({-1})),
+
 
 CartPoleEnv
 ~~~~~~~~~~~
@@ -302,6 +311,19 @@ read/write:
       }
     }
 
+If one of the array for state is dynamic-shaped:
+
+.. code-block:: c++
+
+    Container<int>& dyn = state["obs:dyn"_][i];
+    // new spec
+    auto dyn_spec = ::Spec<int>({env_id_ + 1, spec_.config["state_num"_]});
+    // use this spec to create an array
+    auto* array = new TArray<int>(dyn_spec);
+    // perform some normal array writing
+    // finally pass it to dynamic array
+    dyn.reset(array);
+
 
 Allocate State in Reset and Step
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -344,7 +366,8 @@ interface.
             "obs:players.location"_.Bind(Spec<uint8_t>({-1, 2})),
             "info:players.health"_.Bind(Spec<int>({-1})),
             "info:player_num"_.Bind(Spec<int>({})),
-            "info:bla"_.Bind(Spec<float>({2, 3, 3}))
+            "info:bla"_.Bind(Spec<float>({2, 3, 3})),
+            "info:list"_.Bind(Spec<Container<float>>({-1}))
           );
         }
 
@@ -357,6 +380,7 @@ interface.
         state["info:players.health"];   // shape: (10,)
         state["info:player_num"];       // shape: (), only one element
         state["info:bla"];              // shape: (2, 3, 3)
+        state["info:list"];             // shape: (10,) with dtype=object
 
 .. danger ::
 

--- a/envpool/core/array.h
+++ b/envpool/core/array.h
@@ -142,6 +142,16 @@ class Array {
   }
 
   /**
+   * Fills this array with a scalar value of type T.
+   */
+  template <typename T>
+  void Fill(const T& value) const {
+    DCHECK_EQ(element_size, sizeof(T)) << " element size doesn't match";
+    auto* data = reinterpret_cast<T*>(ptr_.get());
+    std::fill(data, data + size, value);
+  }
+
+  /**
    * Copy the memory starting at `raw.first`, to `raw.first + raw.second` to the
    * memory of this Array.
    */
@@ -157,7 +167,19 @@ class Array {
    * scalar shape.
    */
   template <typename T>
-  operator T() const {  // NOLINT
+  operator const T&() const {  // NOLINT
+    DCHECK_EQ(element_size, sizeof(T)) << " there could be a type mismatch";
+    DCHECK_EQ(size, (std::size_t)1)
+        << " Array with a shape can't be used as a scalar";
+    return *reinterpret_cast<T*>(ptr_.get());
+  }
+
+  /**
+   * Cast the Array to a scalar value of type `T`. This Array needs to have a
+   * scalar shape.
+   */
+  template <typename T>
+  operator T&() {  // NOLINT
     DCHECK_EQ(element_size, sizeof(T)) << " there could be a type mismatch";
     DCHECK_EQ(size, (std::size_t)1)
         << " Array with a shape can't be used as a scalar";

--- a/envpool/core/array.h
+++ b/envpool/core/array.h
@@ -198,4 +198,10 @@ class Array {
   [[nodiscard]] std::shared_ptr<char> SharedPtr() const { return ptr_; }
 };
 
+template <typename Dtype>
+class TArray : public Array {
+ public:
+  explicit TArray(const Spec<Dtype>& spec) : Array(spec) {}
+};
+
 #endif  // ENVPOOL_CORE_ARRAY_H_

--- a/envpool/core/spec.h
+++ b/envpool/core/spec.h
@@ -91,4 +91,22 @@ class Spec : public ShapeSpec {
   }
 };
 
+template <typename dtype>
+class TArray;
+
+template <typename dtype>
+using Container = std::unique_ptr<TArray<dtype>>;
+
+template <typename D>
+class Spec<Container<D>> : public ShapeSpec {
+ public:
+  using dtype = Container<D>;  // NOLINT
+  Spec<D> inner_spec;
+  explicit Spec(const std::vector<int>& shape, const Spec<D>& inner_spec)
+      : ShapeSpec(sizeof(Container<D>), shape), inner_spec(inner_spec) {}
+  explicit Spec(std::vector<int>&& shape, Spec<D>&& inner_spec)
+      : ShapeSpec(sizeof(Container<D>), std::move(shape)),
+        inner_spec(std::move(inner_spec)) {}
+};
+
 #endif  // ENVPOOL_CORE_SPEC_H_

--- a/envpool/dummy/dummy_envpool.h
+++ b/envpool/dummy/dummy_envpool.h
@@ -15,6 +15,8 @@
 #ifndef ENVPOOL_DUMMY_DUMMY_ENVPOOL_H_
 #define ENVPOOL_DUMMY_DUMMY_ENVPOOL_H_
 
+#include <memory>
+
 #include "envpool/core/async_envpool.h"
 #include "envpool/core/env.h"
 
@@ -148,11 +150,15 @@ class DummyEnv : public Env<DummyEnvSpec> {
       state["obs:raw"_](i, 0) = state_;
       state["obs:raw"_](i, 1) = 0;
       state["reward"_][i] = -i;
+      // dynamic array
       Container<int>& dyn = state["obs:dyn"_][i];
-      // this is for dynamic shape array
+      // new spec
       auto dyn_spec = ::Spec<int>({env_id_ + 1, spec_.config["state_num"_]});
-      dyn.reset(new TArray<int>(dyn_spec));
-      dyn->Fill(env_id_);
+      // use this spec to create an array
+      auto* array = new TArray<int>(dyn_spec);
+      // perform some normal array writing
+      // finally pass it to dynamic array
+      dyn.reset(array);
     }
   }
 
@@ -189,7 +195,7 @@ class DummyEnv : public Env<DummyEnvSpec> {
       state["reward"_][i] = -i;
       Container<int>& dyn = state["obs:dyn"_][i];
       auto dyn_spec = ::Spec<int>({env_id_ + 1, spec_.config["state_num"_]});
-      dyn.reset(new TArray<int>(dyn_spec));
+      dyn = std::make_unique<TArray<int>>(dyn_spec);
       dyn->Fill(env_id_);
     }
   }

--- a/envpool/dummy/dummy_envpool.h
+++ b/envpool/dummy/dummy_envpool.h
@@ -74,6 +74,8 @@ class DummyEnvFns {
   template <typename Config>
   static decltype(auto) StateSpec(const Config& conf) {
     return MakeDict("obs"_.Bind(Spec<int>({-1, conf["state_num"_]})),
+                    "dyn"_.Bind(Spec<Container<int>>(
+                        {-1}, Spec<int>({-1, conf["state_num"_]}))),
                     "info:players.done"_.Bind(Spec<bool>({-1})),
                     "info:players.id"_.Bind(
                         Spec<int>({-1}, {0, conf["max_num_players"_]})));

--- a/envpool/dummy/dummy_envpool.h
+++ b/envpool/dummy/dummy_envpool.h
@@ -73,8 +73,8 @@ class DummyEnvFns {
    */
   template <typename Config>
   static decltype(auto) StateSpec(const Config& conf) {
-    return MakeDict("obs"_.Bind(Spec<int>({-1, conf["state_num"_]})),
-                    "dyn"_.Bind(Spec<Container<int>>(
+    return MakeDict("obs:raw"_.Bind(Spec<int>({-1, conf["state_num"_]})),
+                    "obs:dyn"_.Bind(Spec<Container<int>>(
                         {-1}, Spec<int>({-1, conf["state_num"_]}))),
                     "info:players.done"_.Bind(Spec<bool>({-1})),
                     "info:players.id"_.Bind(
@@ -145,10 +145,11 @@ class DummyEnv : public Env<DummyEnvSpec> {
     for (int i = 0; i < num_players; ++i) {
       state["info:players.id"_][i] = i;
       state["info:players.done"_][i] = IsDone();
-      state["obs"_](i, 0) = state_;
-      state["obs"_](i, 1) = 0;
+      state["obs:raw"_](i, 0) = state_;
+      state["obs:raw"_](i, 1) = 0;
       state["reward"_][i] = -i;
-      Container<int>& dyn = state["dyn"_][i];
+      Container<int>& dyn = state["obs:dyn"_][i];
+      // this is for dynamic shape array
       auto dyn_spec = ::Spec<int>({env_id_ + 1, spec_.config["state_num"_]});
       dyn.reset(new TArray<int>(dyn_spec));
       dyn->Fill(env_id_);
@@ -183,10 +184,10 @@ class DummyEnv : public Env<DummyEnvSpec> {
     for (int i = 0; i < num_players; ++i) {
       state["info:players.id"_][i] = i;
       state["info:players.done"_][i] = IsDone();
-      state["obs"_](i, 0) = state_;
-      state["obs"_](i, 1) = action_num;
+      state["obs:raw"_](i, 0) = state_;
+      state["obs:raw"_](i, 1) = action_num;
       state["reward"_][i] = -i;
-      Container<int>& dyn = state["dyn"_][i];
+      Container<int>& dyn = state["obs:dyn"_][i];
       auto dyn_spec = ::Spec<int>({env_id_ + 1, spec_.config["state_num"_]});
       dyn.reset(new TArray<int>(dyn_spec));
       dyn->Fill(env_id_);

--- a/envpool/dummy/dummy_envpool.h
+++ b/envpool/dummy/dummy_envpool.h
@@ -148,6 +148,10 @@ class DummyEnv : public Env<DummyEnvSpec> {
       state["obs"_](i, 0) = state_;
       state["obs"_](i, 1) = 0;
       state["reward"_][i] = -i;
+      Container<int>& dyn = state["dyn"_][i];
+      auto dyn_spec = ::Spec<int>({env_id_ + 1, spec_.config["state_num"_]});
+      dyn.reset(new TArray<int>(dyn_spec));
+      dyn->Fill(state_);
     }
   }
 
@@ -182,6 +186,10 @@ class DummyEnv : public Env<DummyEnvSpec> {
       state["obs"_](i, 0) = state_;
       state["obs"_](i, 1) = action_num;
       state["reward"_][i] = -i;
+      Container<int>& dyn = state["dyn"_][i];
+      auto dyn_spec = ::Spec<int>({action_num, spec_.config["state_num"_]});
+      dyn.reset(new TArray<int>(dyn_spec));
+      dyn->Fill(action_num);
     }
   }
 

--- a/envpool/dummy/dummy_envpool.h
+++ b/envpool/dummy/dummy_envpool.h
@@ -157,6 +157,7 @@ class DummyEnv : public Env<DummyEnvSpec> {
       // use this spec to create an array
       auto* array = new TArray<int>(dyn_spec);
       // perform some normal array writing
+      array->Fill(env_id_);
       // finally pass it to dynamic array
       dyn.reset(array);
     }

--- a/envpool/dummy/dummy_envpool.h
+++ b/envpool/dummy/dummy_envpool.h
@@ -151,7 +151,7 @@ class DummyEnv : public Env<DummyEnvSpec> {
       Container<int>& dyn = state["dyn"_][i];
       auto dyn_spec = ::Spec<int>({env_id_ + 1, spec_.config["state_num"_]});
       dyn.reset(new TArray<int>(dyn_spec));
-      dyn->Fill(state_);
+      dyn->Fill(env_id_);
     }
   }
 
@@ -187,9 +187,9 @@ class DummyEnv : public Env<DummyEnvSpec> {
       state["obs"_](i, 1) = action_num;
       state["reward"_][i] = -i;
       Container<int>& dyn = state["dyn"_][i];
-      auto dyn_spec = ::Spec<int>({action_num, spec_.config["state_num"_]});
+      auto dyn_spec = ::Spec<int>({env_id_ + 1, spec_.config["state_num"_]});
       dyn.reset(new TArray<int>(dyn_spec));
-      dyn->Fill(action_num);
+      dyn->Fill(env_id_);
     }
   }
 

--- a/envpool/dummy/dummy_envpool_test.cc
+++ b/envpool/dummy/dummy_envpool_test.cc
@@ -68,10 +68,10 @@ TEST(DummyEnvPoolTest, SplitZeroAction) {
     EXPECT_EQ(static_cast<int>(obs(i, 1)), counter[p]);
     // check dyn
     const Container<int>& c = dyn[i];
-    EXPECT_EQ(c->Shape(0), counter[p]);
+    EXPECT_EQ(c->Shape(0), p + 1);
     auto* data = reinterpret_cast<int*>(c->Data());
     for (std::size_t j = 0; j < c->size; ++j) {
-      EXPECT_EQ(data[j], counter[p]);
+      EXPECT_EQ(data[j], p);
     }
   }
   // construct continuous action
@@ -99,10 +99,10 @@ TEST(DummyEnvPoolTest, SplitZeroAction) {
     EXPECT_EQ(static_cast<int>(obs(i, 1)), counter[p]);
     // check dyn
     const Container<int>& c = dyn[i];
-    EXPECT_EQ(c->Shape(0), counter[p]);
+    EXPECT_EQ(c->Shape(0), p + 1);
     auto* data = reinterpret_cast<int*>(c->Data());
     for (std::size_t j = 0; j < c->size; ++j) {
-      EXPECT_EQ(data[j], counter[p]);
+      EXPECT_EQ(data[j], p);
     }
   }
 }
@@ -180,9 +180,9 @@ void Runner(int num_envs, int batch, int seed, int total_iter, int num_threads,
       }
       // check dyn
       const Container<int>& c = dyn[i];
-      EXPECT_EQ(c->Shape(0), num_players);
+      EXPECT_EQ(c->Shape(0), eid + 1);
       auto* data = reinterpret_cast<int*>(c->Data());
-      EXPECT_EQ(data[0], num_players);  // checking all is too expensive
+      EXPECT_EQ(data[0], eid);  // checking all is too expensive
     }
 
     for (int i = 0; i < batch; ++i) {

--- a/envpool/dummy/dummy_envpool_test.cc
+++ b/envpool/dummy/dummy_envpool_test.cc
@@ -60,11 +60,19 @@ TEST(DummyEnvPoolTest, SplitZeroAction) {
     EXPECT_EQ(static_cast<int>(state["info:env_id"_][i]), i);
   }
   auto obs = state["obs"_];
+  auto dyn = state["dyn"_];
   auto peid = state["info:players.env_id"_];
   std::vector<int> counter({2, 3, 3, 0});
   for (int i = 0; i < 8; ++i) {
     int p = peid[i];
     EXPECT_EQ(static_cast<int>(obs(i, 1)), counter[p]);
+    // check dyn
+    const Container<int>& c = dyn[i];
+    EXPECT_EQ(c->Shape(0), counter[p]);
+    auto* data = reinterpret_cast<int*>(c->Data());
+    for (std::size_t j = 0; j < c->size; ++j) {
+      EXPECT_EQ(data[j], counter[p]);
+    }
   }
   // construct continuous action
   envpool.Reset(action["env_id"_]);
@@ -83,11 +91,19 @@ TEST(DummyEnvPoolTest, SplitZeroAction) {
     EXPECT_EQ(static_cast<int>(state["info:env_id"_][i]), i);
   }
   obs = state["obs"_];
+  dyn = state["dyn"_];
   peid = state["info:players.env_id"_];
   counter = std::vector<int>({3, 0, 2, 3});
   for (int i = 0; i < 8; ++i) {
     int p = peid[i];
     EXPECT_EQ(static_cast<int>(obs(i, 1)), counter[p]);
+    // check dyn
+    const Container<int>& c = dyn[i];
+    EXPECT_EQ(c->Shape(0), counter[p]);
+    auto* data = reinterpret_cast<int*>(c->Data());
+    for (std::size_t j = 0; j < c->size; ++j) {
+      EXPECT_EQ(data[j], counter[p]);
+    }
   }
 }
 
@@ -125,6 +141,7 @@ void Runner(int num_envs, int batch, int seed, int total_iter, int num_threads,
     auto player_env_id = state["info:players.env_id"_];
     auto player_id = state["info:players.id"_];
     auto obs = state["obs"_];
+    auto dyn = state["dyn"_];
     auto reward = state["reward"_];
     auto done = state["done"_];
     auto player_done = state["info:players.done"_];
@@ -161,6 +178,11 @@ void Runner(int num_envs, int batch, int seed, int total_iter, int num_threads,
       if (is_sync) {
         EXPECT_EQ(eid, i);
       }
+      // check dyn
+      const Container<int>& c = dyn[i];
+      EXPECT_EQ(c->Shape(0), num_players);
+      auto* data = reinterpret_cast<int*>(c->Data());
+      EXPECT_EQ(data[0], num_players);  // checking all is too expensive
     }
 
     for (int i = 0; i < batch; ++i) {

--- a/envpool/dummy/dummy_envpool_test.cc
+++ b/envpool/dummy/dummy_envpool_test.cc
@@ -59,8 +59,8 @@ TEST(DummyEnvPoolTest, SplitZeroAction) {
   for (int i = 0; i < 4; ++i) {
     EXPECT_EQ(static_cast<int>(state["info:env_id"_][i]), i);
   }
-  auto obs = state["obs"_];
-  auto dyn = state["dyn"_];
+  auto obs = state["obs:raw"_];
+  auto dyn = state["obs:dyn"_];
   auto peid = state["info:players.env_id"_];
   std::vector<int> counter({2, 3, 3, 0});
   for (int i = 0; i < 8; ++i) {
@@ -90,8 +90,8 @@ TEST(DummyEnvPoolTest, SplitZeroAction) {
   for (int i = 0; i < 4; ++i) {
     EXPECT_EQ(static_cast<int>(state["info:env_id"_][i]), i);
   }
-  obs = state["obs"_];
-  dyn = state["dyn"_];
+  obs = state["obs:raw"_];
+  dyn = state["obs:dyn"_];
   peid = state["info:players.env_id"_];
   counter = std::vector<int>({3, 0, 2, 3});
   for (int i = 0; i < 8; ++i) {
@@ -140,8 +140,8 @@ void Runner(int num_envs, int batch, int seed, int total_iter, int num_threads,
     auto env_id = state["info:env_id"_];
     auto player_env_id = state["info:players.env_id"_];
     auto player_id = state["info:players.id"_];
-    auto obs = state["obs"_];
-    auto dyn = state["dyn"_];
+    auto obs = state["obs:raw"_];
+    auto dyn = state["obs:dyn"_];
     auto reward = state["reward"_];
     auto done = state["done"_];
     auto player_done = state["info:players.done"_];

--- a/envpool/dummy/dummy_py_envpool_test.py
+++ b/envpool/dummy/dummy_py_envpool_test.py
@@ -58,6 +58,7 @@ class _DummyEnvPoolTest(absltest.TestCase):
     action_spec = dict(zip(action_keys, action_spec))
     # default value of state_num is 10
     self.assertEqual(state_spec["obs"][1][-1], 10)
+    self.assertEqual(state_spec["dyn"][1][1][-1], 10)
     # change conf and see if it can successfully change state_spec
     # directly send dict or expose config as dict?
     conf = dict(zip(_DummyEnvSpec._config_keys, conf))

--- a/envpool/dummy/dummy_py_envpool_test.py
+++ b/envpool/dummy/dummy_py_envpool_test.py
@@ -57,15 +57,15 @@ class _DummyEnvPoolTest(absltest.TestCase):
     state_spec = dict(zip(state_keys, state_spec))
     action_spec = dict(zip(action_keys, action_spec))
     # default value of state_num is 10
-    self.assertEqual(state_spec["obs"][1][-1], 10)
-    self.assertEqual(state_spec["dyn"][1][1][-1], 10)
+    self.assertEqual(state_spec["obs:raw"][1][-1], 10)
+    self.assertEqual(state_spec["obs:dyn"][1][1][-1], 10)
     # change conf and see if it can successfully change state_spec
     # directly send dict or expose config as dict?
     conf = dict(zip(_DummyEnvSpec._config_keys, conf))
     conf["state_num"] = 666
     env_spec = _DummyEnvSpec(tuple(conf.values()))
     state_spec = dict(zip(state_keys, env_spec._state_spec))
-    self.assertEqual(state_spec["obs"][1][-1], 666)
+    self.assertEqual(state_spec["obs:raw"][1][-1], 666)
 
   def test_envpool(self) -> None:
     conf = dict(


### PR DESCRIPTION
## Description

Make `Spec<dtype>` to support `Container<dtype> = std::unique_ptr<TArray<dtype>>`.
The corresponding state/action is converted to a `np.array` of `np.array` on python side.


## Motivation and Context

In certain cases, the state/action of the environment is a dynamic shaped array each time, e.g. sequence of natural language. Currently, only the `num_players` can be configured to be dynamic. With this PR, we can now support dynamic shape of state/action for each env in the batch.

- [ ] I have raised an issue to propose this change ([required](https://envpool.readthedocs.io/en/latest/pages/contributing.html) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make lint` (**required**)
- [x] I have ensured `make bazel-test` pass. (**required**)
