### PR TITLE
Add dm_control speed test script and single env performance benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Here are EnvPool's several highlights:
 - Support both synchronous execution and asynchronous execution;
 - Support both single player and multi-player environment;
 - Easy C++ developer API to add new envs: [Customized C++ environment integration](https://envpool.readthedocs.io/en/latest/content/new_env.html);
+- Free **\~2x** speedup with only single environment;
 - **1 Million** Atari frames / **3 Million** Mujoco steps per second simulation with 256 CPU cores, **~20x** throughput of Python subprocess-based vector env;
 - **~3x** throughput of Python subprocess-based vector env on low resource setup like 12 CPU cores;
 - Comparing with existing GPU-based solution ([Brax](https://github.com/google/brax) / [Isaac-gym](https://developer.nvidia.com/isaac-gym)), EnvPool is a **general** solution for various kinds of speeding-up RL environment parallelization;

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -162,7 +162,38 @@ Use `numactl -s` to determine the number of NUMA cores.
 
 TODO
 
+### Atari and Mujoco Single Environment Tests
+
+Atari and Mujoco (gym) single env test is the same as above with `--num-envs 1`.
+
+For dm\_control suite environment, we provide another benchmark script:
+
+```bash
+python3 test_dmc.py --domain cheetah --task run --total-step 200000
+```
+
 ## Result
+
+### Single Environment Speedup Baseline
+
+<!-- single -->
+
+| System      | Method  | Atari Pong-v5 | Mujoco Ant-v3 | dm_control cheetah run |
+| ----------- | ------- | ------------- | ------------- | ---------------------- |
+| Laptop      | Python  | 4891.65       | 12325.95      | 6235.09                |
+| Laptop      | EnvPool | 7887.51       | 15641.44      | 11636.45               |
+| Laptop      | Speedup | 1.61x         | 1.27x         | 1.87x                  |
+| Workstation | Python  | 7739.15       | 19472.04      |                        |
+| Workstation | EnvPool | 12623.93      | 25725.25      |                        |
+| Workstation | Speedup | 1.63x         | 1.32x         |                        |
+| TPU-VM      | Python  | 3830.19       | 9960.98       |                        |
+| TPU-VM      | EnvPool | 7213.41       | 13706.61      |                        |
+| TPU-VM      | Speedup | 1.88x         | 1.38x         |                        |
+| DGX-A100    | Python  | 4449.38       | 11018.57      |                        |
+| DGX-A100    | EnvPool | 7723.96       | 16024.43      |                        |
+| DGX-A100    | Speedup | 1.74x         | 1.45x         |                        |
+
+<!-- single -->
 
 ### Atari
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -183,15 +183,15 @@ python3 test_dmc.py --domain cheetah --task run --total-step 200000
 | Laptop      | Python  | 4891.65       | 12325.95      | 6235.09                |
 | Laptop      | EnvPool | 7887.51       | 15641.44      | 11636.45               |
 | Laptop      | Speedup | 1.61x         | 1.27x         | 1.87x                  |
-| Workstation | Python  | 7739.15       | 19472.04      |                        |
-| Workstation | EnvPool | 12623.93      | 25725.25      |                        |
-| Workstation | Speedup | 1.63x         | 1.32x         |                        |
-| TPU-VM      | Python  | 3830.19       | 9960.98       |                        |
-| TPU-VM      | EnvPool | 7213.41       | 13706.61      |                        |
-| TPU-VM      | Speedup | 1.88x         | 1.38x         |                        |
-| DGX-A100    | Python  | 4449.38       | 11018.57      |                        |
-| DGX-A100    | EnvPool | 7723.96       | 16024.43      |                        |
-| DGX-A100    | Speedup | 1.74x         | 1.45x         |                        |
+| Workstation | Python  | 7739.15       | 19472.04      | 9042.64                |
+| Workstation | EnvPool | 12623.93      | 25725.25      | 16691.68               |
+| Workstation | Speedup | 1.63x         | 1.32x         | 1.85x                  |
+| TPU-VM      | Python  | 3830.19       | 9960.98       | 5369.07                |
+| TPU-VM      | EnvPool | 7213.41       | 13706.61      | 9987.73                |
+| TPU-VM      | Speedup | 1.88x         | 1.38x         | 1.86x                  |
+| DGX-A100    | Python  | 4449.38       | 11018.57      | 5024.84                |
+| DGX-A100    | EnvPool | 7723.96       | 16024.43      | 10415.87               |
+| DGX-A100    | Speedup | 1.74x         | 1.45x         | 2.07x                  |
 
 <!-- single -->
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -7,7 +7,7 @@ The following results are generated from four types of machine:
 3. TPU-VM: 96 core ``Intel(R) Xeon(R) CPU @ 2.00GHz``, 2 NUMA core, TPU v3-8
 4. DGX-A100: 256 core ``AMD EPYC 7742 64-Core Processor``, 8 NUMA core, 8x A100
 
-We use `PongNoFrameskip-v4` (with environment wrappers from [OpenAI baselines](https://github.com/openai/baselines/blob/master/baselines/common/atari_wrappers.py)) and `Ant-v3` for Atari/Mujoco environment benchmark test with `envpool==0.5.3.post1`. Other packages' versions are all in `requirements.txt`:
+We use `PongNoFrameskip-v4` (with environment wrappers from [OpenAI baselines](https://github.com/openai/baselines/blob/master/baselines/common/atari_wrappers.py)) and `Ant-v3` for Atari/Mujoco environment benchmark test with `envpool==0.6.0`. Other packages' versions are all in `requirements.txt`:
 
 ```bash
 $ pip install -r requirements.txt

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -7,7 +7,7 @@ The following results are generated from four types of machine:
 3. TPU-VM: 96 core ``Intel(R) Xeon(R) CPU @ 2.00GHz``, 2 NUMA core, TPU v3-8
 4. DGX-A100: 256 core ``AMD EPYC 7742 64-Core Processor``, 8 NUMA core, 8x A100
 
-We use `PongNoFrameskip-v4` (with environment wrappers from [OpenAI baselines](https://github.com/openai/baselines/blob/master/baselines/common/atari_wrappers.py)) and `Ant-v3` for Atari/Mujoco environment benchmark test with `envpool==0.6.0`. Other packages' versions are all in `requirements.txt`:
+We use `PongNoFrameskip-v4` (with environment wrappers from [OpenAI baselines](https://github.com/openai/baselines/blob/master/baselines/common/atari_wrappers.py)) and `Ant-v3` for Atari/Mujoco environment benchmark test with `envpool==0.6.1.post1`. Other packages' versions are all in `requirements.txt`:
 
 ```bash
 $ pip install -r requirements.txt

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -1,8 +1,9 @@
 gym[accept-rom-license]==0.23.1
 ale-py==0.7.5
-mujoco==2.1.5
-envpool==0.5.3.post1
+mujoco==2.2.0
+envpool==0.6.0
 sample-factory==1.123.0
 mujoco_py==2.1.2.14
 tqdm
 opencv-python-headless
+dm_control==1.0.3.post1

--- a/benchmark/requirements.txt
+++ b/benchmark/requirements.txt
@@ -1,7 +1,7 @@
 gym[accept-rom-license]==0.23.1
 ale-py==0.7.5
 mujoco==2.2.0
-envpool==0.6.0
+envpool==0.6.1.post1
 sample-factory==1.123.0
 mujoco_py==2.1.2.14
 tqdm

--- a/benchmark/test_dmc.py
+++ b/benchmark/test_dmc.py
@@ -1,0 +1,83 @@
+# Copyright 2022 Garena Online Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import time
+
+import numpy as np
+import tqdm
+from dm_control import suite
+
+import envpool
+
+
+def run_dmc(env, action, frame_skip, total_step):
+  ts = env.reset()
+  t = time.time()
+  for i in tqdm.trange(total_step):
+    if ts.discount == 0:
+      ts = env.reset()
+    else:
+      ts = env.step(action[i])
+  fps = frame_skip * total_step / (time.time() - t)
+  print(f"FPS(dmc) = {fps:.2f}")
+  return fps
+
+
+def run_envpool(env, action, frame_skip, total_step):
+  ts = env.reset()
+  t = time.time()
+  for i in tqdm.trange(total_step):
+    if ts.discount[0] == 0:
+      ts = env.reset()
+    else:
+      ts = env.step(action[i:i + 1])
+  fps = frame_skip * total_step / (time.time() - t)
+  print(f"FPS(envpool) = {fps:.2f}")
+  return fps
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--domain", type=str, default="cheetah")
+  parser.add_argument("--task", type=str, default="run")
+  parser.add_argument("--total-step", type=int, default=200000)
+  parser.add_argument("--seed", type=int, default=0)
+  args = parser.parse_args()
+  print(args)
+
+  # dmc
+  env = suite.load(args.domain, args.task, {"random": args.seed})
+  np.random.seed(args.seed)
+  minimum, maximum = env.action_spec().minimum, env.action_spec().maximum
+  action = np.array(
+    [
+      np.random.uniform(low=minimum, high=maximum)
+      for _ in range(args.total_step)
+    ]
+  )
+  frame_skip = env._n_sub_steps
+
+  fps_dmc = run_dmc(env, action, frame_skip, args.total_step)
+
+  time.sleep(3)
+
+  # envpool
+  domain_name = "".join([i.capitalize() for i in args.domain.split("_")])
+  task_name = "".join([i.capitalize() for i in args.task.split("_")])
+  env = envpool.make_dm(f"{domain_name}{task_name}-v1", num_envs=1)
+  assert env.spec.config.frame_skip == frame_skip
+
+  fps_envpool = run_envpool(env, action, frame_skip, args.total_step)
+  print(f"EnvPool Speedup: {fps_envpool / fps_dmc:.2f}x")

--- a/benchmark/test_envpool.py
+++ b/benchmark/test_envpool.py
@@ -50,7 +50,10 @@ import envpool
 if __name__ == "__main__":
   parser = argparse.ArgumentParser()
   parser.add_argument(
-    "--env", type=str, default="atari", choices=["atari", "mujoco", "vizdoom"]
+    "--env",
+    type=str,
+    default="atari",
+    choices=["atari", "mujoco", "vizdoom", "box2d"],
   )
   parser.add_argument("--num-envs", type=int, default=645)
   parser.add_argument("--batch-size", type=int, default=248)
@@ -66,6 +69,7 @@ if __name__ == "__main__":
     "atari": "Pong-v5",
     "mujoco": "Ant-v3",
     "vizdoom": "HealthGathering-v1",
+    "box2d": "LunarLander-v2",
   }[args.env]
   kwargs = dict(
     num_envs=args.num_envs,

--- a/docs/content/benchmark.rst
+++ b/docs/content/benchmark.rst
@@ -8,7 +8,7 @@ The following results are generated from four types of machine:
 3. TPU-VM: 96 core ``Intel(R) Xeon(R) CPU @ 2.00GHz``, 2 NUMA core, TPU v3-8
 4. DGX-A100: 256 core ``AMD EPYC 7742 64-Core Processor``, 8 NUMA core, 8x A100
 
-We use ``PongNoFrameskip-v4`` (with environment wrappers from `OpenAI baselines <https://github.com/openai/baselines/blob/master/baselines/common/atari_wrappers.py>`__) and ``Ant-v3`` for Atari/Mujoco environment benchmark test with ``envpool==0.5.3.post1``. Other packages’ versions are all in ``requirements.txt``:
+We use ``PongNoFrameskip-v4`` (with environment wrappers from `OpenAI baselines <https://github.com/openai/baselines/blob/master/baselines/common/atari_wrappers.py>`__) and ``Ant-v3`` for Atari/Mujoco environment benchmark test with ``envpool==0.6.0``. Other packages’ versions are all in ``requirements.txt``:
 
 .. code:: bash
 
@@ -180,8 +180,47 @@ Brax and Isaac-gym (Mujoco only)
 
 TODO
 
+Atari and Mujoco Single Environment Tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Atari and Mujoco (gym) single env test is the same as above with ``--num-envs 1``.
+
+For dm_control suite environment, we provide another benchmark script:
+
+.. code:: bash
+
+   python3 test_dmc.py --domain cheetah --task run --total-step 200000
+
 Result
 ------
+
+Single Environment Speedup Baseline
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. raw:: html
+
+   <!-- single -->
+
+=========== ======= ============= ============= ======================
+System      Method  Atari Pong-v5 Mujoco Ant-v3 dm_control cheetah run
+=========== ======= ============= ============= ======================
+Laptop      Python  4891.65       12325.95      6235.09
+Laptop      EnvPool 7887.51       15641.44      11636.45
+Laptop      Speedup 1.61x         1.27x         1.87x
+Workstation Python  7739.15       19472.04      9042.64
+Workstation EnvPool 12623.93      25725.25      16691.68
+Workstation Speedup 1.63x         1.32x         1.85x
+TPU-VM      Python  3830.19       9960.98       5369.07
+TPU-VM      EnvPool 7213.41       13706.61      9987.73
+TPU-VM      Speedup 1.88x         1.38x         1.86x
+DGX-A100    Python  4449.38       11018.57      5024.84
+DGX-A100    EnvPool 7723.96       16024.43      10415.87
+DGX-A100    Speedup 1.74x         1.45x         2.07x
+=========== ======= ============= ============= ======================
+
+.. raw:: html
+
+   <!-- single -->
 
 Atari
 ~~~~~

--- a/docs/content/benchmark.rst
+++ b/docs/content/benchmark.rst
@@ -8,7 +8,7 @@ The following results are generated from four types of machine:
 3. TPU-VM: 96 core ``Intel(R) Xeon(R) CPU @ 2.00GHz``, 2 NUMA core, TPU v3-8
 4. DGX-A100: 256 core ``AMD EPYC 7742 64-Core Processor``, 8 NUMA core, 8x A100
 
-We use ``PongNoFrameskip-v4`` (with environment wrappers from `OpenAI baselines <https://github.com/openai/baselines/blob/master/baselines/common/atari_wrappers.py>`__) and ``Ant-v3`` for Atari/Mujoco environment benchmark test with ``envpool==0.6.0``. Other packages’ versions are all in ``requirements.txt``:
+We use ``PongNoFrameskip-v4`` (with environment wrappers from `OpenAI baselines <https://github.com/openai/baselines/blob/master/baselines/common/atari_wrappers.py>`__) and ``Ant-v3`` for Atari/Mujoco environment benchmark test with ``envpool==0.6.1.post1``. Other packages’ versions are all in ``requirements.txt``:
 
 .. code:: bash
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Here are EnvPool's several highlights:
 - Support both synchronous execution and asynchronous execution;
 - Support both single player and multi-player environment;
 - Easy C++ developer API to add new envs;
+- Free **~2x** speedup with only single environment;
 - **1 Million** Atari frames / **3 Million** Mujoco steps per second
   simulation with 256 CPU cores, **~20x** throughput of Python
   subprocess-based vector env;


### PR DESCRIPTION
The initial result shows we have at least 2x speedup than dm_control with only a single env. Pending integrating mujoco from source code (just release 8h ago).