### PR TITLE
replace dm-tree with treevalue

### DIFF
--- a/envpool/python/BUILD
+++ b/envpool/python/BUILD
@@ -24,7 +24,7 @@ py_library(
     name = "data",
     srcs = ["data.py"],
     deps = [
-        requirement("dm-tree"),
+        requirement("treevalue"),
         requirement("dm-env"),
         requirement("gym"),
         requirement("numpy"),
@@ -48,7 +48,7 @@ py_library(
     name = "envpool",
     srcs = ["envpool.py"],
     deps = [
-        requirement("dm-tree"),
+        requirement("treevalue"),
         requirement("dm-env"),
         requirement("numpy"),
         requirement("packaging"),
@@ -81,7 +81,7 @@ py_library(
     name = "dm_envpool",
     srcs = ["dm_envpool.py"],
     deps = [
-        requirement("dm-tree"),
+        requirement("treevalue"),
         requirement("dm-env"),
         requirement("numpy"),
         ":data",
@@ -95,7 +95,7 @@ py_library(
     name = "gym_envpool",
     srcs = ["gym_envpool.py"],
     deps = [
-        requirement("dm-tree"),
+        requirement("treevalue"),
         requirement("dm-env"),
         requirement("gym"),
         requirement("numpy"),

--- a/envpool/python/data.py
+++ b/envpool/python/data.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Tuple, Type
 import dm_env
 import gym
 import numpy as np
-import tree
+import treevalue
 
 from .protocol import ArraySpec
 
@@ -116,14 +116,15 @@ def dm_structure(root_name: str, keys: List[str]) -> Tuple[Tuple, List[int]]:
     key = key.replace("obs:", f"{root_name}:")  # compatible with to_namedtuple
     new_keys.append(key.replace(":", "."))
   dict_tree = to_nested_dict(dict(zip(new_keys, list(range(len(new_keys))))))
-  structure = to_namedtuple(root_name, dict_tree)
-  indice = tree.flatten(structure)
-  return structure, indice
+  tree_pairs = treevalue.flatten(treevalue.TreeValue(dict_tree))
+  indice = list(zip(*tree_pairs))[-1]
+  return tree_pairs, indice
 
 
 def gym_structure(keys: List[str]) -> Tuple[Dict[str, Any], List[int]]:
   """Convert flat keys into tree structure for dict construction."""
   keys = [k.replace(":", ".") for k in keys]
   structure = to_nested_dict(dict(zip(keys, list(range(len(keys))))))
-  indice = tree.flatten(structure)
-  return structure, indice
+  tree_pairs = treevalue.flatten(treevalue.TreeValue(structure))
+  indice = list(zip(*tree_pairs))[-1]
+  return tree_pairs, indice

--- a/envpool/python/data.py
+++ b/envpool/python/data.py
@@ -106,7 +106,8 @@ def gym_spec_transform(
   )
 
 
-def dm_structure(root_name: str, keys: List[str]) -> Tuple[Tuple, List[int]]:
+def dm_structure(root_name: str,
+                 keys: List[str]) -> List[Tuple[List[str], int]]:
   """Convert flat keys into tree structure for namedtuple construction."""
   new_keys = []
   for key in keys:
@@ -117,14 +118,12 @@ def dm_structure(root_name: str, keys: List[str]) -> Tuple[Tuple, List[int]]:
     new_keys.append(key.replace(":", "."))
   dict_tree = to_nested_dict(dict(zip(new_keys, list(range(len(new_keys))))))
   tree_pairs = treevalue.flatten(treevalue.TreeValue(dict_tree))
-  indice = list(zip(*tree_pairs))[-1]
-  return tree_pairs, indice
+  return tree_pairs
 
 
-def gym_structure(keys: List[str]) -> Tuple[Dict[str, Any], List[int]]:
+def gym_structure(keys: List[str]) -> List[Tuple[List[str], int]]:
   """Convert flat keys into tree structure for dict construction."""
   keys = [k.replace(":", ".") for k in keys]
   structure = to_nested_dict(dict(zip(keys, list(range(len(keys))))))
   tree_pairs = treevalue.flatten(treevalue.TreeValue(structure))
-  indice = list(zip(*tree_pairs))[-1]
-  return tree_pairs, indice
+  return tree_pairs

--- a/envpool/python/dm_envpool.py
+++ b/envpool/python/dm_envpool.py
@@ -64,7 +64,8 @@ class DMEnvPoolMeta(ABCMeta):
     check_key_duplication(name, "state", state_keys)
     check_key_duplication(name, "action", action_keys)
 
-    tree_pairs, state_idx = dm_structure("State", state_keys)
+    tree_pairs = dm_structure("State", state_keys)
+    state_idx = list(zip(*tree_pairs))[-1]
 
     def _to_dm(
       self: Any,

--- a/envpool/python/dm_envpool.py
+++ b/envpool/python/dm_envpool.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Tuple, Union, no_type_check
 
 import dm_env
 import numpy as np
-import tree
+import treevalue
 from dm_env import TimeStep
 
 from .data import dm_structure
@@ -64,7 +64,7 @@ class DMEnvPoolMeta(ABCMeta):
     check_key_duplication(name, "state", state_keys)
     check_key_duplication(name, "action", action_keys)
 
-    state_structure, state_idx = dm_structure("State", state_keys)
+    tree_pairs, state_idx = dm_structure("State", state_keys)
 
     def _to_dm(
       self: Any,
@@ -72,8 +72,9 @@ class DMEnvPoolMeta(ABCMeta):
       reset: bool,
       return_info: bool,
     ) -> TimeStep:
-      state = tree.unflatten_as(
-        state_structure, [state_values[i] for i in state_idx]
+      values = [state_values[i] for i in state_idx]
+      state = treevalue.unflatten(
+        [(path, vi) for (path, _), vi in zip(tree_pairs, values)]
       )
       done = state.done
       elapse = state.elapsed_step

--- a/envpool/python/envpool.py
+++ b/envpool/python/envpool.py
@@ -19,7 +19,7 @@ from abc import ABC
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import tree
+import treevalue
 from dm_env import TimeStep
 
 from .protocol import EnvPool, EnvSpec
@@ -59,7 +59,9 @@ class EnvPoolMixin(ABC):
   ) -> List[np.ndarray]:
     """Convert action to C++-acceptable format."""
     if isinstance(action, dict):
-      adict = {".".join(k): v for k, v in tree.flatten_with_path(action)}
+      atree = treevalue.TreeValue(action)
+      alist = treevalue.flatten(atree)
+      adict = {".".join(k): v for k, v in alist}
     else:  # only 3 keys in action_keys
       if isinstance(action, np.ndarray):
         # else it could be a jax array, when using xla

--- a/envpool/python/gym_envpool.py
+++ b/envpool/python/gym_envpool.py
@@ -83,18 +83,16 @@ class GymEnvPoolMeta(ABCMeta, gym.Env.__class__):
       elapse = state["elapsed_step"]
       max_episode_steps = self.config.get("max_episode_steps", np.inf)
       trunc = (done & (elapse >= max_episode_steps))
+      info = treevalue.jsonify(state["info"])
       if not new_gym_api:
-        state["info"]["TimeLimit.truncated"] = trunc
-      state["info"]["elapsed_step"] = state["elapsed_step"]
+        info["TimeLimit.truncated"] = trunc
+      info["elapsed_step"] = state["elapsed_step"]
       if reset:
-        return state["obs"], treevalue.jsonify(state["info"])
+        return state["obs"], info
       if new_gym_api:
         terminated = done & ~trunc
-        return state["obs"], state[
-          "reward"], terminated, trunc, treevalue.jsonify(state["info"])
-      return state["obs"], state["reward"], state["done"], treevalue.jsonify(
-        state["info"]
-      )
+        return state["obs"], state["reward"], terminated, trunc, info
+      return state["obs"], state["reward"], state["done"], info
 
     attrs["_to"] = _to_gym
     subcls = super().__new__(cls, name, parents, attrs)

--- a/envpool/python/gym_envpool.py
+++ b/envpool/python/gym_envpool.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Tuple, Union, no_type_check
 
 import gym
 import numpy as np
-import tree
+import treevalue
 from packaging import version
 
 from .data import gym_structure
@@ -64,7 +64,7 @@ class GymEnvPoolMeta(ABCMeta, gym.Env.__class__):
     check_key_duplication(name, "state", state_keys)
     check_key_duplication(name, "action", action_keys)
 
-    state_structure, state_idx = gym_structure(state_keys)
+    tree_pairs, state_idx = gym_structure(state_keys)
 
     new_gym_api = version.parse(gym.__version__) >= version.parse("0.26.0")
 
@@ -72,8 +72,9 @@ class GymEnvPoolMeta(ABCMeta, gym.Env.__class__):
       self: Any, state_values: List[np.ndarray], reset: bool, return_info: bool
     ) -> Union[Any, Tuple[Any, Any], Tuple[Any, np.ndarray, np.ndarray, Any],
                Tuple[Any, np.ndarray, np.ndarray, np.ndarray, Any]]:
-      state = tree.unflatten_as(
-        state_structure, [state_values[i] for i in state_idx]
+      values = [state_values[i] for i in state_idx]
+      state = treevalue.unflatten(
+        [(path, vi) for (path, _), vi in zip(tree_pairs, values)]
       )
       if reset and not (return_info or new_gym_api):
         return state["obs"]
@@ -85,11 +86,14 @@ class GymEnvPoolMeta(ABCMeta, gym.Env.__class__):
         state["info"]["TimeLimit.truncated"] = trunc
       state["info"]["elapsed_step"] = state["elapsed_step"]
       if reset:
-        return state["obs"], state["info"]
+        return state["obs"], treevalue.jsonify(state["info"])
       if new_gym_api:
         terminated = done & ~trunc
-        return state["obs"], state["reward"], terminated, trunc, state["info"]
-      return state["obs"], state["reward"], state["done"], state["info"]
+        return state["obs"], state[
+          "reward"], terminated, trunc, treevalue.jsonify(state["info"])
+      return state["obs"], state["reward"], state["done"], treevalue.jsonify(
+        state["info"]
+      )
 
     attrs["_to"] = _to_gym
     subcls = super().__new__(cls, name, parents, attrs)

--- a/envpool/python/gym_envpool.py
+++ b/envpool/python/gym_envpool.py
@@ -64,7 +64,8 @@ class GymEnvPoolMeta(ABCMeta, gym.Env.__class__):
     check_key_duplication(name, "state", state_keys)
     check_key_duplication(name, "action", action_keys)
 
-    tree_pairs, state_idx = gym_structure(state_keys)
+    tree_pairs = gym_structure(state_keys)
+    state_idx = list(zip(*tree_pairs))[-1]
 
     new_gym_api = version.parse(gym.__version__) >= version.parse("0.26.0")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     types-protobuf>=3.17.3
     typing-extensions
     packaging
+    treevalue>=1.4
 
 [options.packages.find]
 include = envpool*

--- a/third_party/pip_requirements/requirements.txt
+++ b/third_party/pip_requirements/requirements.txt
@@ -2,6 +2,7 @@ absl-py
 cloudpickle
 dm-env
 dm-tree
+treevalue>=1.4.1
 dm-control>=1.0.5
 filelock
 gym>=0.26

--- a/third_party/pip_requirements/requirements.txt
+++ b/third_party/pip_requirements/requirements.txt
@@ -2,13 +2,13 @@ absl-py
 cloudpickle
 dm-env
 dm-tree
-treevalue>=1.4.1
+treevalue>=1.4
 dm-control>=1.0.5
 filelock
 gym>=0.26
 pygame
 box2d
-mujoco>=2.2.1
+mujoco>=2.2.1,<2.3
 mujoco_py>=2.1.2.14
 h5py
 jinja2


### PR DESCRIPTION
## Description

Replaced dm-tree with treevalue for better performance. 

## Motivation and Context

treevalue is significantly faster than dm-tree. 

After fix, envpool's speedup increased from ~0.5x to ~0.7x: 
```
Namespace(domain='cheetah', seed=0, task='run', total_step=200000)
100%|███████████████████████████████████████████████████████████████████████████████████████████████| 200000/200000 [00:16<00:00, 11769.05it/s]
FPS(dmc) = 11766.68
100%|████████████████████████████████████████████████████████████████████████████████████████████████| 200000/200000 [00:24<00:00, 8241.72it/s]
FPS(envpool) = 8241.51
EnvPool Speedup: 0.70x
```

- [ ] I have raised an issue to propose this change ([required](https://envpool.readthedocs.io/en/latest/pages/contributing.html) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [x] replace dm-tree with treevalue in envpool

## Checklist

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make lint` (**required**)
- [ ] I have ensured `make bazel-test` pass. (**required**)
