### PR TITLE
further speedup

### DIFF
--- a/envpool/python/dm_envpool.py
+++ b/envpool/python/dm_envpool.py
@@ -73,7 +73,7 @@ class DMEnvPoolMeta(ABCMeta):
       reset: bool,
       return_info: bool,
     ) -> TimeStep:
-      values = [state_values[i] for i in state_idx]
+      values = map(lambda i: state_values[i], state_idx)
       state = treevalue.unflatten(
         [(path, vi) for (path, _), vi in zip(tree_pairs, values)]
       )

--- a/envpool/python/envpool.py
+++ b/envpool/python/envpool.py
@@ -63,10 +63,14 @@ class EnvPoolMixin(ABC):
       alist = treevalue.flatten(atree)
       adict = {".".join(k): v for k, v in alist}
     else:  # only 3 keys in action_keys
+      if not hasattr(self, "_last_action_type"):
+        self._last_action_type = self._spec._action_spec[-1][0]
+      if not hasattr(self, "_last_action_name"):
+        self._last_action_name = self._spec._action_keys[-1]
       if isinstance(action, np.ndarray):
         # else it could be a jax array, when using xla
-        action = action.astype(self._spec._action_spec[-1][0], order='C')
-      adict = {self._spec._action_keys[-1]: action}
+        action = action.astype(self._last_action_type, order='C')
+      adict = {self._last_action_name: action}
     if env_id is None:
       if "env_id" not in adict:
         adict["env_id"] = self.all_env_ids
@@ -74,7 +78,9 @@ class EnvPoolMixin(ABC):
       adict["env_id"] = env_id.astype(np.int32)
     if "players.env_id" not in adict:
       adict["players.env_id"] = adict["env_id"]
-    return list(map(lambda k: adict[k], self._spec._action_keys))
+    if not hasattr(self, "_action_names"):
+      self._action_names = self._spec._action_keys
+    return list(map(lambda k: adict[k], self._action_names))
 
   def __len__(self: EnvPool) -> int:
     """Return the number of environments."""
@@ -83,7 +89,9 @@ class EnvPoolMixin(ABC):
   @property
   def all_env_ids(self: EnvPool) -> np.ndarray:
     """All env_id in numpy ndarray with dtype=np.int32."""
-    return np.arange(self.config["num_envs"], dtype=np.int32)
+    if not hasattr(self, "_all_env_ids"):
+      self._all_env_ids = np.arange(self.config["num_envs"], dtype=np.int32)
+    return self._all_env_ids
 
   @property
   def is_async(self: EnvPool) -> bool:

--- a/envpool/python/envpool.py
+++ b/envpool/python/envpool.py
@@ -70,8 +70,9 @@ class EnvPoolMixin(ABC):
       if isinstance(action, np.ndarray):
         # else it could be a jax array, when using xla
         action = action.astype(
-          self._last_action_type, order='C'
-        )  # type: ignore
+          self._last_action_type,  # type: ignore
+          order='C',
+        )
       adict = {self._last_action_name: action}  # type: ignore
     if env_id is None:
       if "env_id" not in adict:

--- a/envpool/python/envpool.py
+++ b/envpool/python/envpool.py
@@ -69,8 +69,10 @@ class EnvPoolMixin(ABC):
         self._last_action_name = self._spec._action_keys[-1]
       if isinstance(action, np.ndarray):
         # else it could be a jax array, when using xla
-        action = action.astype(self._last_action_type, order='C')
-      adict = {self._last_action_name: action}
+        action = action.astype(
+          self._last_action_type, order='C'
+        )  # type: ignore
+      adict = {self._last_action_name: action}  # type: ignore
     if env_id is None:
       if "env_id" not in adict:
         adict["env_id"] = self.all_env_ids
@@ -80,7 +82,7 @@ class EnvPoolMixin(ABC):
       adict["players.env_id"] = adict["env_id"]
     if not hasattr(self, "_action_names"):
       self._action_names = self._spec._action_keys
-    return list(map(lambda k: adict[k], self._action_names))
+    return list(map(lambda k: adict[k], self._action_names))  # type: ignore
 
   def __len__(self: EnvPool) -> int:
     """Return the number of environments."""
@@ -91,7 +93,7 @@ class EnvPoolMixin(ABC):
     """All env_id in numpy ndarray with dtype=np.int32."""
     if not hasattr(self, "_all_env_ids"):
       self._all_env_ids = np.arange(self.config["num_envs"], dtype=np.int32)
-    return self._all_env_ids
+    return self._all_env_ids  # type: ignore
 
   @property
   def is_async(self: EnvPool) -> bool:

--- a/envpool/python/gym_envpool.py
+++ b/envpool/python/gym_envpool.py
@@ -73,7 +73,7 @@ class GymEnvPoolMeta(ABCMeta, gym.Env.__class__):
       self: Any, state_values: List[np.ndarray], reset: bool, return_info: bool
     ) -> Union[Any, Tuple[Any, Any], Tuple[Any, np.ndarray, np.ndarray, Any],
                Tuple[Any, np.ndarray, np.ndarray, np.ndarray, Any]]:
-      values = [state_values[i] for i in state_idx]
+      values = map(lambda i: state_values[i], state_idx)
       state = treevalue.unflatten(
         [(path, vi) for (path, _), vi in zip(tree_pairs, values)]
       )


### PR DESCRIPTION
## Description

Cache spec attr to speedup, profile result says reading `self._spec.xxx` takes a lot of time.

## Motivation and Context

After fix, envpool's speedup increased from ~0.9x to ~1.1x:

```
Namespace(domain='cheetah', seed=0, task='run', total_step=200000)
100%|███████████████████████████████████████████████████████████████████████████████████████████████| 200000/200000 [00:16<00:00, 12291.98it/s]
FPS(dmc) = 12289.97
100%|███████████████████████████████████████████████████████████████████████████████████████████████| 200000/200000 [00:14<00:00, 14146.43it/s]
FPS(envpool) = 14145.82
EnvPool Speedup: 1.15x
```

- [ ] I have raised an issue to propose this change ([required](https://envpool.readthedocs.io/en/latest/pages/contributing.html) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [ ] Subtask 1
- [ ] Subtask 2
- [ ] Subtask 3

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make lint` (**required**)
- [x] I have ensured `make bazel-test` pass. (**required**)
