### PR TITLE
lazy import

### DIFF
--- a/envpool/entry.py
+++ b/envpool/entry.py
@@ -13,11 +13,42 @@
 # limitations under the License.
 """Entry point for all envs' registration."""
 
-import envpool.atari.registration  # noqa: F401
-import envpool.box2d.registration  # noqa: F401
-import envpool.classic_control.registration  # noqa: F401
-import envpool.mujoco.dmc.registration  # noqa: F401
-import envpool.mujoco.gym.registration  # noqa: F401
-import envpool.procgen.registration  # noqa: F401
-import envpool.toy_text.registration  # noqa: F401
-import envpool.vizdoom.registration  # noqa: F401
+try:
+  import envpool.atari.registration  # noqa: F401
+except ImportError:
+  pass
+
+try:
+  import envpool.box2d.registration  # noqa: F401
+except ImportError:
+  pass
+
+try:
+  import envpool.classic_control.registration  # noqa: F401
+except ImportError:
+  pass
+
+try:
+  import envpool.mujoco.dmc.registration  # noqa: F401
+except ImportError:
+  pass
+
+try:
+  import envpool.mujoco.gym.registration  # noqa: F401
+except ImportError:
+  pass
+
+try:
+  import envpool.procgen.registration  # noqa: F401
+except ImportError:
+  pass
+
+try:
+  import envpool.toy_text.registration  # noqa: F401
+except ImportError:
+  pass
+
+try:
+  import envpool.vizdoom.registration  # noqa: F401
+except ImportError:
+  pass


### PR DESCRIPTION
Currently, `import envpool` on fresh devbox will raise error because of procgen qt5 dependency.