### PR TITLE
chore: add timeout flag for pip requirements installation

### DIFF
--- a/envpool/pip.bzl
+++ b/envpool/pip.bzl
@@ -23,6 +23,8 @@ def workspace():
         pip_install(
             name = "pip_requirements",
             python_interpreter = "python3",
+            # default timeout value is 600, change it if you failed.
+            # timeout = 3600,
             quiet = False,
             requirements = "@envpool//third_party/pip_requirements:requirements.txt",
             # extra_pip_args = ["--extra-index-url", "https://mirrors.aliyun.com/pypi/simple"],


### PR DESCRIPTION
## Description

find a way to extend timeout of pip requirements installation, really helpful if in CN

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make lint` (**required**)
- [x] I have ensured `make bazel-test` pass. (**required**)
