### PR TITLE
fix(hansbug): use treevalue 1.4.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     types-protobuf>=3.17.3
     typing-extensions
     packaging
-    treevalue>=1.4
+    treevalue>=1.4.6
 
 [options.packages.find]
 include = envpool*

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     types-protobuf>=3.17.3
     typing-extensions
     packaging
-    treevalue>=1.4.6
+    treevalue>=1.4.7
 
 [options.packages.find]
 include = envpool*

--- a/third_party/pip_requirements/requirements-dev.txt
+++ b/third_party/pip_requirements/requirements-dev.txt
@@ -4,7 +4,7 @@ numpy
 dm-env
 gym>=0.26
 gymnasium>=0.26,!=0.27.0
-treevalue>=1.4
+treevalue>=1.4.6
 jax[cpu]
 absl-py
 packaging

--- a/third_party/pip_requirements/requirements-dev.txt
+++ b/third_party/pip_requirements/requirements-dev.txt
@@ -10,7 +10,7 @@ absl-py
 packaging
 tqdm
 protobuf<=4.20.0
-torch
+torch!=2.0.0
 tianshou>=0.4.10
 opencv-python-headless
 box2d-py

--- a/third_party/pip_requirements/requirements-dev.txt
+++ b/third_party/pip_requirements/requirements-dev.txt
@@ -4,7 +4,7 @@ numpy
 dm-env
 gym>=0.26
 gymnasium>=0.26,!=0.27.0
-treevalue>=1.4.6
+treevalue>=1.4.7
 jax[cpu]
 absl-py
 packaging

--- a/third_party/pip_requirements/requirements-release.txt
+++ b/third_party/pip_requirements/requirements-release.txt
@@ -4,5 +4,5 @@ numpy
 dm-env
 gym>=0.26
 gymnasium>=0.26,!=0.27.0
-treevalue>=1.4.6
+treevalue>=1.4.7
 jax[cpu]

--- a/third_party/pip_requirements/requirements-release.txt
+++ b/third_party/pip_requirements/requirements-release.txt
@@ -4,5 +4,5 @@ numpy
 dm-env
 gym>=0.26
 gymnasium>=0.26,!=0.27.0
-treevalue>=1.4
+treevalue>=1.4.6
 jax[cpu]


### PR DESCRIPTION
## Description

The treevalue is not upgraded to `1.4.7`, which supports:
1. generic_flatten, generic_unflatten and generic_mapping functions, here are [some examples](https://opendilab.github.io/treevalue/v1.4.7/api_doc/tree/integration.html#generic-flatten).  **With `generic_flatten` and `generic_unflatten`, the problem of non-native instances mentioned by @XuehaiPan will be easily solved**.

```python
In [1]: from collections import namedtuple
   ...: from easydict import EasyDict
   ...: from treevalue import FastTreeValue
   ...: 
   ...: class MyTreeValue(FastTreeValue):
   ...:     pass
   ...: 
   ...: nt = namedtuple('nt', ['a', 'b'])
   ...: 
   ...: origin = {
   ...:     'a': 1,
   ...:     'b': (2, 3, 'f',),
   ...:     'c': (2, 5, 'ds', {
   ...:         'x': None,
   ...:         'z': [34, '1.2'],
   ...:     }),
   ...:     'd': nt('f', 100),  # namedtuple
   ...:     'e': MyTreeValue({'x': 1, 'y': 'dsfljk'})  # treevalue
   ...: }

In [2]: from treevalue import generic_flatten
   ...: 
   ...: v, spec = generic_flatten(origin)
   ...: v
Out[2]: [1, [2, 3, 'f'], [2, 5, 'ds', [None, [34, '1.2']]], ['f', 100], [1, 'dsfljk']]

In [3]: from treevalue import generic_unflatten
   ...: 
   ...: generic_unflatten(v, spec)
Out[3]: 
{'a': 1,
 'b': (2, 3, 'f'),
 'c': (2, 5, 'ds', {'x': None, 'z': [34, '1.2']}),
 'd': nt(a='f', b=100),
 'e': <MyTreeValue 0x7fd552b5b410>
 ├── 'x' --> 1
 └── 'y' --> 'dsfljk'}
```

With `generic_mapping`, **the operations can be performed on the entire structure** (even including custom classes, you can register this with [`register_integrate_container`](https://opendilab.github.io/treevalue/v1.4.7/api_doc/tree/integration.html#register-integrate-container)) with good performance, here is the metrics.

![1677503026559](https://user-images.githubusercontent.com/20508435/221570959-550940e8-22aa-4ee3-9967-260c6dfb0199.png)
![1677502998652](https://user-images.githubusercontent.com/20508435/221570895-efa6b35f-3663-42e1-8837-763579b2e850.png)
![1677498651795](https://user-images.githubusercontent.com/20508435/221570554-18361578-323d-421b-b932-c898b5ee8a2d.png)
![1677498667831](https://user-images.githubusercontent.com/20508435/221570567-60cee69b-cebc-48ab-9eb8-ea7f3c1ec158.png)

2. We support the torch pytree's intregration, this is the newest example

```python
In [1]: import torch
   ...: 
   ...: from treevalue import FastTreeValue
   ...: 
   ...: d = {'a': 1, 'b': {'c': 2, 'd': 3}, 'e': 4}
   ...: t = FastTreeValue(d)
   ...: 

In [2]: torch.utils._pytree.tree_flatten(t)  # Torch recognizes TreeValue as tree
Out[2]: 
([1, 2, 3, 4],
 TreeSpec(FastTreeValue, (<class 'treevalue.tree.general.fast.FastTreeValue'>, [('a',), ('b', 'c'), ('b', 'd'), ('e',)]), [*, *, *, *]))
```

3. We provide `unpack` method for quickly unpack the values from treevalue. We should also notice that the treevalue's behaviour is similar to `dict`, not namedtuple. It also need to consider the nested structures like dict does.

```python
In [1]: from treevalue import FastTreeValue
   ...: 
   ...: d = {'a': 1, 'b': {'c': 2, 'd': 3}, 'e': 4}
   ...: t = FastTreeValue(d)
   ...: 

In [2]: vc, vd = t.b.unpack('c', 'd')

In [3]: vc
Out[3]: 2

In [4]: vd
Out[4]: 3
```

4. We are really really glad to see @XuehaiPan @Benjamin-eecs bring some more advise to `treevalue`. This will make `treevalue` better and better since we are able to add all these new features asap. We hope to have more in-depth exchanges with the optree team in order to significantly improve the experience of using treevalue. 😄 


--------------- old description ---------------

Fix bug https://github.com/sail-sg/envpool/issues/246, by just use the newest version of treevalue.

## Motivation and Context

This is a simple fix of bug https://github.com/sail-sg/envpool/issues/246 .

In the treevalue `1.4.6`, the `TreeValue` and `FastTreeValue` class, which can satisfy almost all of the actual usage, are registered as jax nodes by default. If custom `TreeValue`-based class need to be registered, you can just do like this

```python
from treevalue import FastTreeValue, register_for_jax


class MyTreeValue(FastTreeValue):
    pass


register_for_jax(MyTreeValue)  # such a simple operation, isn't it?
```

Not only that, from an engineering point of view, maintaining the original design as much as possible is a strategy that is more conducive to code maintenance, and directly upgrading the treevalue version will **minimize the reconstruction to the code and technology stack**. A series of convenient calculation operation provided by treevalue (see the [documentation of treevalue](https://opendilab.github.io/treevalue/main/index.html) for details) are also very tempting for the subsequent development of the project, and the performance is fully sufficient to meet the requirements. Among the users of envpool, jax is not a must, and **users who do not use jax are also common**. It is obvious that treevalue has **better versatility and universality**.  In summary, **we recommend upgrading the version of treevalue to fix this bug**.

BTW, If you have further optimization needs and suggestions, we will respond asap.

- [x] I have raised an issue to propose this change ([required](https://envpool.readthedocs.io/en/latest/pages/contributing.html) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make lint` (**required**)
- [x] I have ensured `make bazel-test` pass. (**required**)
