### PR TITLE
Type checking Action/State

### DIFF
--- a/benchmark/test_envpool.py
+++ b/benchmark/test_envpool.py
@@ -82,9 +82,7 @@ if __name__ == "__main__":
   env = envpool.make_gym(task_id, **kwargs)
   env.async_reset()
   env.action_space.seed(args.seed)
-  action = np.array(
-    [env.action_space.sample() for _ in range(args.batch_size)]
-  )
+  action = np.array([env.action_space.sample() for _ in range(args.batch_size)])
   t = time.time()
   for _ in tqdm.trange(args.total_step):
     info = env.recv()[-1]

--- a/benchmark/test_gym.py
+++ b/benchmark/test_gym.py
@@ -33,9 +33,8 @@ def run(env, num_envs, total_step, async_):
       )
     else:
       env = gym.vector.make(
-        task_id, num_envs, async_, lambda e: wrap_deepmind(
-          e, episode_life=False, clip_rewards=False, frame_stack=4
-        )
+        task_id, num_envs, async_, lambda e:
+        wrap_deepmind(e, episode_life=False, clip_rewards=False, frame_stack=4)
       )
   elif env == "mujoco":
     task_id = "Ant-v3"

--- a/envpool/atari/api_test.py
+++ b/envpool/atari/api_test.py
@@ -36,9 +36,7 @@ class _SpecTest(absltest.TestCase):
       action_num = action_nums[task]
       spec = make_spec(task.capitalize() + "-v5")
       logging.info(spec)
-      self.assertEqual(
-        spec.action_array_spec["action"].maximum + 1, action_num
-      )
+      self.assertEqual(spec.action_array_spec["action"].maximum + 1, action_num)
       # check dm spec
       dm_obs_spec = spec.observation_spec().obs
       dm_act_spec = spec.action_spec()
@@ -126,9 +124,7 @@ class _DMSyncTest(absltest.TestCase):
     self.assertEqual(ts.observation.lives.dtype, np.int32)
     np.testing.assert_allclose(ts.observation.env_id, np.arange(num_envs))
     self.assertEqual(ts.observation.env_id.dtype, np.int32)
-    np.testing.assert_allclose(
-      ts.observation.players.env_id.shape, (num_envs,)
-    )
+    np.testing.assert_allclose(ts.observation.players.env_id.shape, (num_envs,))
     self.assertEqual(ts.observation.players.env_id.dtype, np.int32)
     action = {
       "env_id": np.arange(num_envs),
@@ -178,9 +174,7 @@ class _DMSyncTest(absltest.TestCase):
     self.assertEqual(ts.observation.lives.dtype, np.int32)
     np.testing.assert_allclose(ts.observation.env_id, np.arange(num_envs))
     self.assertEqual(ts.observation.env_id.dtype, np.int32)
-    np.testing.assert_allclose(
-      ts.observation.players.env_id.shape, (num_envs,)
-    )
+    np.testing.assert_allclose(ts.observation.players.env_id.shape, (num_envs,))
     self.assertEqual(ts.observation.players.env_id.dtype, np.int32)
     action = {
       "env_id": np.arange(num_envs),

--- a/envpool/box2d/box2d_correctness_test.py
+++ b/envpool/box2d/box2d_correctness_test.py
@@ -262,9 +262,7 @@ class _Box2dEnvPoolCorrectnessTest(absltest.TestCase):
       env_id = env_id[~done]
       hs = hs[~done]
 
-      ah = [
-        self.heuristic_bipedal_walker_policy(s, h) for s, h in zip(obs, hs)
-      ]
+      ah = [self.heuristic_bipedal_walker_policy(s, h) for s, h in zip(obs, hs)]
       action = np.array([i[0] for i in ah])
       hs = np.array([i[1] for i in ah])
 

--- a/envpool/core/array.h
+++ b/envpool/core/array.h
@@ -164,30 +164,6 @@ class Array {
   }
 
   /**
-   * Cast the Array to a scalar value of type `T`. This Array needs to have a
-   * scalar shape.
-   */
-  template <typename T>
-  operator const T&() const {  // NOLINT
-    DCHECK_EQ(element_size, sizeof(T)) << " there could be a type mismatch";
-    DCHECK_EQ(size, (std::size_t)1)
-        << " Array with a shape can't be used as a scalar";
-    return *reinterpret_cast<T*>(ptr_.get());
-  }
-
-  /**
-   * Cast the Array to a scalar value of type `T`. This Array needs to have a
-   * scalar shape.
-   */
-  template <typename T>
-  operator T&() {  // NOLINT
-    DCHECK_EQ(element_size, sizeof(T)) << " there could be a type mismatch";
-    DCHECK_EQ(size, (std::size_t)1)
-        << " Array with a shape can't be used as a scalar";
-    return *reinterpret_cast<T*>(ptr_.get());
-  }
-
-  /**
    * Size of axis `dim`.
    */
   [[nodiscard]] inline std::size_t Shape(std::size_t dim) const {
@@ -223,8 +199,104 @@ class Array {
 
 template <typename Dtype>
 class TArray : public Array {
+  template <class Shape, class Deleter>
+  TArray(char* ptr, Shape&& shape, std::size_t element_size,  // NOLINT
+         Deleter&& deleter)
+      : Array(ptr, shape, element_size, deleter) {}
+
+  template <class Shape>
+  TArray(std::shared_ptr<char> ptr, Shape&& shape, std::size_t element_size)
+      : Array(ptr, shape, element_size) {}
+
  public:
+  TArray() = default;
   explicit TArray(const Spec<Dtype>& spec) : Array(spec) {}
+  explicit TArray(const Spec<Dtype>& spec, char* data) : Array(spec, data) {}
+
+  template <typename A, std::enable_if_t<std::is_same_v<std::decay_t<A>, Array>,
+                                         bool> = true>
+  explicit TArray(A&& array) : Array(std::forward<A>(array)) {
+    DCHECK_EQ(array.element_size, sizeof(Dtype));
+  }
+
+  /**
+   * Take multidimensional index into the Array.
+   */
+  template <typename... Index>
+  inline TArray operator()(Index... index) const {
+    return TArray(Array::operator()(index...));
+  }
+
+  /**
+   * Index operator of array, takes the index along the first axis.
+   */
+  inline TArray operator[](int index) const {
+    return TArray(this->operator()(index));
+  }
+
+  /**
+   * Take a slice at the first axis of the Array.
+   */
+  [[nodiscard]] TArray Slice(std::size_t start, std::size_t end) const {
+    return TArray(Array::Slice(start, end));
+  }
+
+  /**
+   * Copy the content of another Array to this Array.
+   */
+  void Assign(const TArray& value) const { Array::Assign(value); }
+  void Assign(const Array& value) const { Array::Assign(value); }
+
+  /**
+   * Assign a scalar value.
+   */
+  template <typename T,
+            std::enable_if_t<!std::is_same_v<T, TArray>, bool> = true>
+  void operator=(const T& value) const {
+    *reinterpret_cast<Dtype*>(ptr_.get()) = static_cast<Dtype>(value);
+  }
+
+  /**
+   * Fills this array with a scalar value of type T.
+   */
+  template <typename T>
+  void Fill(const T& value) const {
+    Dtype* data = reinterpret_cast<Dtype*>(ptr_.get());
+    std::fill(data, data + size, static_cast<Dtype>(value));
+  }
+
+  /**
+   * Copy the memory starting at `raw.first`, to `raw.first + raw.second` to the
+   * memory of this Array.
+   */
+  void Assign(const Dtype* buff, std::size_t sz) const {
+    std::memcpy(ptr_.get(), buff, sz * sizeof(Dtype));
+  }
+
+  operator Dtype&() const { return *reinterpret_cast<Dtype*>(ptr_.get()); }
+
+  /**
+   * Cast the Array to a scalar value of type `T`. This Array needs to have a
+   * scalar shape.
+   */
+  template <typename T,
+            std::enable_if_t<std::is_same_v<T, Dtype>, bool> = false>
+  operator T() const {  // NOLINT
+    DCHECK_EQ(size, (std::size_t)1)
+        << " Array with a non-scalar shape can't be used as a scalar";
+    return static_cast<T>(*reinterpret_cast<Dtype*>(ptr_.get()));
+  }
+
+  /**
+   * Truncate the Array. Return a new Array that shares the same memory
+   * location but with a truncated shape.
+   */
+  [[nodiscard]] TArray Truncate(std::size_t end) const {
+    auto new_shape = std::vector<std::size_t>(shape_);
+    new_shape[0] = end;
+    TArray ret(ptr_, std::move(new_shape), element_size);
+    return ret;
+  }
 };
 
 #endif  // ENVPOOL_CORE_ARRAY_H_

--- a/envpool/core/array.h
+++ b/envpool/core/array.h
@@ -134,7 +134,8 @@ class Array {
    * Assign to this Array a scalar value. This Array needs to have a scalar
    * shape.
    */
-  template <typename T>
+  template <typename T,
+            std::enable_if_t<!std::is_same_v<T, Array>, bool> = true>
   void operator=(const T& value) const {
     DCHECK_EQ(element_size, sizeof(T)) << " element size doesn't match";
     DCHECK_EQ(size, (std::size_t)1) << " assigning scalar to non-scalar array";

--- a/envpool/core/array.h
+++ b/envpool/core/array.h
@@ -232,9 +232,7 @@ class TArray : public Array {
   /**
    * Index operator of array, takes the index along the first axis.
    */
-  inline TArray operator[](int index) const {
-    return TArray(this->operator()(index));
-  }
+  inline TArray operator[](int index) const { return this->operator()(index); }
 
   /**
    * Take a slice at the first axis of the Array.

--- a/envpool/core/async_envpool.h
+++ b/envpool/core/async_envpool.h
@@ -175,12 +175,12 @@ class AsyncEnvPool : public EnvPool<typename Env::Spec> {
   }
 
   void Reset(const Array& env_ids) override {
-    TArray<int> env_ids_(env_ids);
-    int shared_offset = env_ids_.Shape(0);
+    TArray<int> tenv_ids(env_ids);
+    int shared_offset = tenv_ids.Shape(0);
     std::vector<ActionSlice> actions(shared_offset);
     for (int i = 0; i < shared_offset; ++i) {
       actions[i].force_reset = true;
-      actions[i].env_id = env_ids_[i];
+      actions[i].env_id = tenv_ids[i];
       actions[i].order = is_sync_ ? i : -1;
     }
     if (is_sync_) {

--- a/envpool/core/async_envpool.h
+++ b/envpool/core/async_envpool.h
@@ -154,6 +154,8 @@ class AsyncEnvPool : public EnvPool<typename Env::Spec> {
     }
   }
 
+  void Send(const Action& action) {
+    SendImpl(action.template AllValues<Array>());
   }
   void Send(const std::vector<Array>& action) override { SendImpl(action); }
   void Send(std::vector<Array>&& action) override { SendImpl(action); }
@@ -173,11 +175,12 @@ class AsyncEnvPool : public EnvPool<typename Env::Spec> {
   }
 
   void Reset(const Array& env_ids) override {
-    int shared_offset = env_ids.Shape(0);
+    TArray<int> env_ids_(env_ids);
+    int shared_offset = env_ids_.Shape(0);
     std::vector<ActionSlice> actions(shared_offset);
     for (int i = 0; i < shared_offset; ++i) {
       actions[i].force_reset = true;
-      actions[i].env_id = env_ids[i];
+      actions[i].env_id = env_ids_[i];
       actions[i].order = is_sync_ ? i : -1;
     }
     if (is_sync_) {

--- a/envpool/core/dict.h
+++ b/envpool/core/dict.h
@@ -135,6 +135,8 @@ class Dict : public std::decay_t<TupleOrVector> {
         << "Size must match";
   }
 
+  Dict() = default;
+
   /**
    * Constructor, makes a dict from keys and values
    */
@@ -152,6 +154,12 @@ class Dict : public std::decay_t<TupleOrVector> {
   explicit Dict(TupleOrVector&& values) : Values(std::move(values)) { Check(); }
 
   explicit Dict(const TupleOrVector& values) : Values(values) { Check(); }
+
+  template <typename V, typename V2 = Values,
+            std::enable_if_t<is_vector_v<std::decay_t<V>>, bool> = true,
+            std::enable_if_t<is_tuple_v<V2>, bool> = true>
+  explicit Dict(V&& values)
+      : Dict(tuple_from_vector<Values>(std::forward<V>(values))) {}
 
   /**
    * Gives the values a [index] based accessor

--- a/envpool/core/dict.h
+++ b/envpool/core/dict.h
@@ -158,8 +158,8 @@ class Dict : public std::decay_t<TupleOrVector> {
   template <typename V, typename V2 = Values,
             std::enable_if_t<is_vector_v<std::decay_t<V>>, bool> = true,
             std::enable_if_t<is_tuple_v<V2>, bool> = true>
-  explicit Dict(V&& values)
-      : Dict(tuple_from_vector<Values>(std::forward<V>(values))) {}
+  explicit Dict(V&& values)  // NOLINT
+      : Dict(TupleFromVector<Values>(std::forward<V>(values))) {}
 
   /**
    * Gives the values a [index] based accessor

--- a/envpool/core/env.h
+++ b/envpool/core/env.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <random>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/envpool/core/env.h
+++ b/envpool/core/env.h
@@ -52,7 +52,7 @@ struct SpecToTArray;
 
 template <typename... Args>
 struct SpecToTArray<std::tuple<Args...>> {
-  using type = std::tuple<TArray<typename Args::dtype>...>;
+  using Type = std::tuple<TArray<typename Args::dtype>...>;
 };
 
 /**
@@ -82,10 +82,10 @@ class Env {
   using Spec = EnvSpec;
   using State =
       Dict<typename EnvSpec::StateKeys,
-           typename SpecToTArray<typename EnvSpec::StateSpec::Values>::type>;
+           typename SpecToTArray<typename EnvSpec::StateSpec::Values>::Type>;
   using Action =
       Dict<typename EnvSpec::ActionKeys,
-           typename SpecToTArray<typename EnvSpec::ActionSpec::Values>::type>;
+           typename SpecToTArray<typename EnvSpec::ActionSpec::Values>::Type>;
 
   Env(const EnvSpec& spec, int env_id)
       : max_num_players_(spec.config["max_num_players"_]),

--- a/envpool/core/env_spec.h
+++ b/envpool/core/env_spec.h
@@ -48,6 +48,7 @@ auto common_state_spec =
 template <typename EnvFns>
 class EnvSpec {
  public:
+  using EnvFnsType = EnvFns;
   using Config = decltype(ConcatDict(common_config, EnvFns::DefaultConfig()));
   using ConfigKeys = typename Config::Keys;
   using ConfigValues = typename Config::Values;

--- a/envpool/core/envpool.h
+++ b/envpool/core/envpool.h
@@ -39,6 +39,9 @@ class EnvPool {
   virtual void Send(const std::vector<Array>& action) {
     throw std::runtime_error("send not implemented");
   }
+  virtual void Send(std::vector<Array>&& action) {
+    throw std::runtime_error("send not implemented");
+  }
   virtual std::vector<Array> Recv() {
     throw std::runtime_error("recv not implemented");
   }

--- a/envpool/core/state_buffer.h
+++ b/envpool/core/state_buffer.h
@@ -144,9 +144,7 @@ class StateBuffer {
     uint64_t offsets = offsets_;
     uint32_t player_offset = (offsets >> 32);
     uint32_t shared_offset = offsets;
-    DCHECK_EQ((std::size_t)shared_offset, batch_)
-        << "When this StateBuffer is ready, the shared state arrays should "
-           "be used up.";
+    DCHECK_EQ((std::size_t)shared_offset, batch_ - additional_done_count);
     std::vector<Array> ret;
     ret.reserve(arrays_.size());
     for (std::size_t i = 0; i < arrays_.size(); ++i) {

--- a/envpool/core/state_buffer_queue_test.cc
+++ b/envpool/core/state_buffer_queue_test.cc
@@ -113,7 +113,7 @@ TEST(StateBufferQueueTest, NumPlayers) {
     EXPECT_EQ(slice.arr[1].Shape(0), 1);
     size += num_players;
   }
-  std::vector<Array> out = queue.Wait();
+  std::vector<Array> out = queue.Wait(batch * max_num_players - size);
   EXPECT_EQ(out[0].Shape(0), size);
   EXPECT_EQ(out[1].Shape(0), batch);
 }

--- a/envpool/core/state_buffer_test.cc
+++ b/envpool/core/state_buffer_test.cc
@@ -62,7 +62,7 @@ TEST(StateBufferTest, SinglePlayerSync) {
     EXPECT_EQ(std::get<0>(offset), std::get<1>(offset));
     EXPECT_EQ(r.arr[0].Shape(), std::vector<std::size_t>({10, 2, 2}));
     EXPECT_EQ(r.arr[1].Shape(), std::vector<std::size_t>({1, 2, 2}));
-    r.arr[1] = i;  // only the first element is modified
+    r.arr[1](0, 0, 0) = i;  // only the first element is modified
     r.done_write();
   }
   auto bs = buffer.Wait();

--- a/envpool/core/state_buffer_test.cc
+++ b/envpool/core/state_buffer_test.cc
@@ -83,8 +83,7 @@ TEST(StateBufferTest, Truncate) {
                      std::vector<bool>({false, true}));
   auto r = buffer.Allocate(player_num);
   r.done_write();
-  buffer.Done(batch - 1);
-  auto bs = buffer.Wait();
+  auto bs = buffer.Wait(batch - 1);
   EXPECT_EQ(bs[0].Shape(), std::vector<std::size_t>({1, 10, 2, 2}));
   EXPECT_EQ(bs[1].Shape(), std::vector<std::size_t>(
                                {static_cast<std::size_t>(player_num), 2, 2}));

--- a/envpool/core/tuple_utils.h
+++ b/envpool/core/tuple_utils.h
@@ -49,20 +49,20 @@ template <typename... T>
 using tuple_cat_t = decltype(std::tuple_cat(std::declval<T>()...));  // NOLINT
 
 template <typename TupleType, typename T, std::size_t... Is>
-decltype(auto) tuple_from_vector_impl(std::index_sequence<Is...>,
-                                      const std::vector<T>& arguments) {
+decltype(auto) TupleFromVectorImpl(std::index_sequence<Is...> /*unused*/,
+                                   const std::vector<T>& arguments) {
   return TupleType(arguments[Is]...);
 }
 
 template <typename TupleType, typename T, std::size_t... Is>
-decltype(auto) tuple_from_vector_impl(std::index_sequence<Is...>,
-                                      std::vector<T>&& arguments) {
+decltype(auto) TupleFromVectorImpl(std::index_sequence<Is...> /*unused*/,
+                                   std::vector<T>&& arguments) {
   return TupleType(std::move(arguments[Is])...);
 }
 
 template <typename TupleType, typename V>
-decltype(auto) tuple_from_vector(V&& arguments) {
-  return tuple_from_vector_impl<TupleType>(
+decltype(auto) TupleFromVector(V&& arguments) {
+  return TupleFromVectorImpl<TupleType>(
       std::make_index_sequence<std::tuple_size_v<TupleType>>{},
       std::forward<V>(arguments));
 }

--- a/envpool/core/tuple_utils.h
+++ b/envpool/core/tuple_utils.h
@@ -21,6 +21,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 template <class T, class Tuple>
 struct Index;
@@ -46,5 +47,24 @@ decltype(auto) ApplyZip(F&& f, K&& k, V&& v,
 
 template <typename... T>
 using tuple_cat_t = decltype(std::tuple_cat(std::declval<T>()...));  // NOLINT
+
+template <typename TupleType, typename T, std::size_t... Is>
+decltype(auto) tuple_from_vector_impl(std::index_sequence<Is...>,
+                                      const std::vector<T>& arguments) {
+  return TupleType(arguments[Is]...);
+}
+
+template <typename TupleType, typename T, std::size_t... Is>
+decltype(auto) tuple_from_vector_impl(std::index_sequence<Is...>,
+                                      std::vector<T>&& arguments) {
+  return TupleType(std::move(arguments[Is])...);
+}
+
+template <typename TupleType, typename V>
+decltype(auto) tuple_from_vector(V&& arguments) {
+  return tuple_from_vector_impl<TupleType>(
+      std::make_index_sequence<std::tuple_size_v<TupleType>>{},
+      std::forward<V>(arguments));
+}
 
 #endif  // ENVPOOL_CORE_TUPLE_UTILS_H_

--- a/envpool/core/xla.h
+++ b/envpool/core/xla.h
@@ -189,7 +189,7 @@ struct XlaRecv {
     int max_num_players = envpool->spec.config["max_num_players"_];
     std::vector<Array> recv = envpool->Recv();
     for (std::size_t i = 0; i < recv.size(); ++i) {
-      CHECK_LE(recv[i].Shape(0), batch_size * max_num_players);
+      CHECK_LE(recv[i].Shape(0), (std::size_t)batch_size * max_num_players);
       std::memcpy(out[i], recv[i].Data(), recv[i].size * recv[i].element_size);
     }
   }
@@ -200,7 +200,7 @@ struct XlaRecv {
     int max_num_players = envpool->spec.config["max_num_players"_];
     std::vector<Array> recv = envpool->Recv();
     for (std::size_t i = 0; i < recv.size(); ++i) {
-      CHECK_LE(recv[i].Shape(0), batch_size * max_num_players);
+      CHECK_LE(recv[i].Shape(0), (std::size_t)batch_size * max_num_players);
       cudaMemcpyAsync(out[i], recv[i].Data(),
                       recv[i].size * recv[i].element_size,
                       cudaMemcpyHostToDevice, stream);

--- a/envpool/dummy/dummy_envpool_test.cc
+++ b/envpool/dummy/dummy_envpool_test.cc
@@ -43,7 +43,7 @@ TEST(DummyEnvPoolTest, SplitZeroAction) {
   std::vector<Array> raw_action({Array(Spec<int>({4})), Array(Spec<int>({8})),
                                  Array(Spec<double>({4, 6})),
                                  Array(Spec<int>({8})), Array(Spec<int>({8}))});
-  DummyAction action(&raw_action);
+  DummyAction action(raw_action);
   for (int i = 0; i < 4; ++i) {
     action["env_id"_][i] = i;
     for (int j = 0; j < 6; ++j) {
@@ -56,8 +56,7 @@ TEST(DummyEnvPoolTest, SplitZeroAction) {
   }
   // send
   envpool.Send(action);
-  state_vec = envpool.Recv();
-  DummyState state(&state_vec);
+  DummyState state(envpool.Recv());
   EXPECT_EQ(action["env_id"_].Shape(0), state["info:env_id"_].Shape(0));
   EXPECT_EQ(state["info:players.env_id"_].Shape(0), 8);
   for (int i = 0; i < 4; ++i) {
@@ -87,8 +86,7 @@ TEST(DummyEnvPoolTest, SplitZeroAction) {
   }
   // send
   envpool.Send(action);
-  state_vec = envpool.Recv();
-  state = DummyState(&state_vec);
+  state = DummyState(envpool.Recv());
   EXPECT_EQ(action["env_id"_].Shape(0), state["info:env_id"_].Shape(0));
   EXPECT_EQ(state["info:players.env_id"_].Shape(0), 8);
   for (int i = 0; i < 4; ++i) {
@@ -130,12 +128,12 @@ void Runner(int num_envs, int batch, int seed, int total_iter, int num_threads,
   }
   dummy::DummyEnvSpec spec(config);
   dummy::DummyEnvPool envpool(spec);
-  Array all_env_ids(Spec<int>({num_envs}));
+  TArray all_env_ids(Spec<int>({num_envs}));
   for (int i = 0; i < num_envs; ++i) {
     all_env_ids[i] = i;
   }
   envpool.Reset(all_env_ids);
-  auto list_action = Array(Spec<double>({num_envs, 6}));
+  auto list_action = TArray(Spec<double>({num_envs, 6}));
   for (int i = 0; i < num_envs; ++i) {
     for (int j = 0; j < 6; ++j) {
       list_action[i][j] = 5.0 + i;
@@ -144,8 +142,7 @@ void Runner(int num_envs, int batch, int seed, int total_iter, int num_threads,
   auto start = std::chrono::system_clock::now();
   for (int i = 0; i < total_iter; ++i) {
     // recv
-    auto state_vec = envpool.Recv();
-    DummyState state(&state_vec);
+    DummyState state(envpool.Recv());
     // check state
     auto env_id = state["info:env_id"_];
     auto player_env_id = state["info:players.env_id"_];
@@ -205,8 +202,7 @@ void Runner(int num_envs, int batch, int seed, int total_iter, int num_threads,
       }
     }
     // construct action
-    std::vector<Array> raw_action(5);
-    DummyAction action(&raw_action);
+    DummyAction action;
     action["env_id"_] = env_id;
     action["players.env_id"_] = player_env_id;
     action["list_action"_] = list_action;

--- a/envpool/mujoco/gym/mujoco_gym_envpool_test.cc
+++ b/envpool/mujoco/gym/mujoco_gym_envpool_test.cc
@@ -39,7 +39,7 @@ TEST(MjcEnvPoolTest, CheckAction) {
   std::vector<Array> raw_action({Array(Spec<int>({num_envs})),
                                  Array(Spec<int>({num_envs})),
                                  Array(Spec<double>({num_envs, 6}))});
-  MjcAction action(&raw_action);
+  MjcAction action(raw_action);
   for (int i = 0; i < num_envs; ++i) {
     action["env_id"_][i] = i;
     action["players.env_id"_][i] = i;

--- a/envpool/procgen/procgen_env_test.cc
+++ b/envpool/procgen/procgen_env_test.cc
@@ -33,16 +33,14 @@ TEST(PRocgenEnvTest, BasicStep) {
   int total_iter = 10000;
   procgen::ProcgenEnvSpec spec(config);
   procgen::ProcgenEnvPool envpool(spec);
-  Array all_env_ids(Spec<int>({static_cast<int>(batch)}));
+  TArray all_env_ids(Spec<int>({static_cast<int>(batch)}));
   for (std::size_t i = 0; i < batch; ++i) {
     all_env_ids[i] = i;
   }
   envpool.Reset(all_env_ids);
-  std::vector<Array> raw_action(3);
-  ProcgenAction action(&raw_action);
+  ProcgenAction action;
   for (int i = 0; i < total_iter; ++i) {
-    auto state_vec = envpool.Recv();
-    ProcgenState state(&state_vec);
+    ProcgenState state(envpool.Recv());
     EXPECT_EQ(state["obs"_].Shape(),
               std::vector<std::size_t>({batch, 3, 64, 64}));
     uint8_t* data = static_cast<uint8_t*>(state["obs"_].Data());
@@ -57,7 +55,7 @@ TEST(PRocgenEnvTest, BasicStep) {
     }
     action["env_id"_] = state["info:env_id"_];
     action["players.env_id"_] = state["info:env_id"_];
-    action["action"_] = Array(Spec<int>({static_cast<int>(batch)}));
+    action["action"_] = TArray(Spec<int>({static_cast<int>(batch)}));
     for (std::size_t j = 0; j < batch; ++j) {
       action["action"_][j] = std::rand() % 15;
     }

--- a/envpool/python/data.py
+++ b/envpool/python/data.py
@@ -88,9 +88,7 @@ def dm_spec_transform(
   )
 
 
-def gym_spec_transform(
-  name: str, spec: ArraySpec, spec_type: str
-) -> gym.Space:
+def gym_spec_transform(name: str, spec: ArraySpec, spec_type: str) -> gym.Space:
   """Transform ArraySpec to gym.Env compatible spaces."""
   if np.prod(np.abs(spec.shape)) == 1 and \
       np.isclose(spec.minimum, 0) and spec.maximum < ACTION_THRESHOLD:

--- a/envpool/python/dm_envpool.py
+++ b/envpool/python/dm_envpool.py
@@ -57,9 +57,7 @@ class DMEnvPoolMeta(ABCMeta):
     except ImportError:
 
       def _xla(self: Any) -> None:
-        raise RuntimeError(
-          "XLA is disabled. To enable XLA please install jax."
-        )
+        raise RuntimeError("XLA is disabled. To enable XLA please install jax.")
 
       attrs["xla"] = _xla
       parents = (base, DMEnvPoolMixin, EnvPoolMixin, dm_env.Environment)

--- a/envpool/python/env_spec.py
+++ b/envpool/python/env_spec.py
@@ -83,7 +83,7 @@ class EnvSpecMixin(ABC):
     spec = self.state_array_spec
     spec = {
       k.replace("obs:", "").replace("info:", ""):
-      dm_spec_transform(k.replace(":", ".").split(".")[-1], v, "obs")
+        dm_spec_transform(k.replace(":", ".").split(".")[-1], v, "obs")
       for k, v in spec.items()
       if k.startswith("obs") or k.startswith("info")
     }
@@ -131,7 +131,7 @@ class EnvSpecMixin(ABC):
     spec = self.state_array_spec
     spec = {
       k.replace("obs:", ""):
-      gym_spec_transform(k.replace(":", ".").split(".")[-1], v, "obs")
+        gym_spec_transform(k.replace(":", ".").split(".")[-1], v, "obs")
       for k, v in spec.items()
       if k.startswith("obs")
     }
@@ -162,8 +162,7 @@ class EnvSpecMixin(ABC):
         list(spec.values())[0], "act"
       )
     spec = {
-      k: gym_spec_transform(k.split(".")[-1], v, "act")
-      for k, v in spec.items()
+      k: gym_spec_transform(k.split(".")[-1], v, "act") for k, v in spec.items()
     }
     return to_nested_dict(spec, gym.spaces.Dict)
 
@@ -184,7 +183,7 @@ class EnvSpecMixin(ABC):
     spec = self.state_array_spec
     spec = {
       k.replace("obs:", ""):
-      gymnasium_spec_transform(k.replace(":", ".").split(".")[-1], v, "obs")
+        gymnasium_spec_transform(k.replace(":", ".").split(".")[-1], v, "obs")
       for k, v in spec.items()
       if k.startswith("obs")
     }

--- a/envpool/python/envpool.py
+++ b/envpool/python/envpool.py
@@ -101,9 +101,7 @@ class EnvPoolMixin(ABC):
     return self.config["batch_size"] > 0 and self.config[
       "num_envs"] != self.config["batch_size"]
 
-  def seed(
-    self: EnvPool, seed: Optional[Union[int, List[int]]] = None
-  ) -> None:
+  def seed(self: EnvPool, seed: Optional[Union[int, List[int]]] = None) -> None:
     """Set the seed for all environments (abandoned)."""
     warnings.warn(
       "The `seed` function in envpool is abandoned. "

--- a/envpool/python/gym_envpool.py
+++ b/envpool/python/gym_envpool.py
@@ -57,9 +57,7 @@ class GymEnvPoolMeta(ABCMeta, gym.Env.__class__):
     except ImportError:
 
       def _xla(self: Any) -> None:
-        raise RuntimeError(
-          "XLA is disabled. To enable XLA please install jax."
-        )
+        raise RuntimeError("XLA is disabled. To enable XLA please install jax.")
 
       attrs["xla"] = _xla
       parents = (base, GymEnvPoolMixin, EnvPoolMixin, gym.Env)

--- a/envpool/python/gym_envpool.py
+++ b/envpool/python/gym_envpool.py
@@ -75,8 +75,12 @@ class GymEnvPoolMeta(ABCMeta, gym.Env.__class__):
 
     def _to_gym(
       self: Any, state_values: List[np.ndarray], reset: bool, return_info: bool
-    ) -> Union[Any, Tuple[Any, Any], Tuple[Any, np.ndarray, np.ndarray, Any],
-               Tuple[Any, np.ndarray, np.ndarray, np.ndarray, Any],]:
+    ) -> Union[
+      Any,
+      Tuple[Any, Any],
+      Tuple[Any, np.ndarray, np.ndarray, Any],
+      Tuple[Any, np.ndarray, np.ndarray, np.ndarray, Any],
+    ]:
       values = (state_values[i] for i in state_idx)
       state = optree.tree_unflatten(treepsec, values)
       if reset and not (return_info or new_gym_api):

--- a/envpool/python/gymnasium_envpool.py
+++ b/envpool/python/gymnasium_envpool.py
@@ -74,8 +74,12 @@ class GymnasiumEnvPoolMeta(ABCMeta, gymnasium.Env.__class__):
 
     def _to_gymnasium(
       self: Any, state_values: List[np.ndarray], reset: bool, return_info: bool
-    ) -> Union[Any, Tuple[Any, Any], Tuple[Any, np.ndarray, np.ndarray, Any],
-               Tuple[Any, np.ndarray, np.ndarray, np.ndarray, Any],]:
+    ) -> Union[
+      Any,
+      Tuple[Any, Any],
+      Tuple[Any, np.ndarray, np.ndarray, Any],
+      Tuple[Any, np.ndarray, np.ndarray, np.ndarray, Any],
+    ]:
       values = (state_values[i] for i in state_idx)
       state = optree.tree_unflatten(treepsec, values)
       info = state["info"]

--- a/envpool/python/gymnasium_envpool.py
+++ b/envpool/python/gymnasium_envpool.py
@@ -58,9 +58,7 @@ class GymnasiumEnvPoolMeta(ABCMeta, gymnasium.Env.__class__):
     except ImportError:
 
       def _xla(self: Any) -> None:
-        raise RuntimeError(
-          "XLA is disabled. To enable XLA please install jax."
-        )
+        raise RuntimeError("XLA is disabled. To enable XLA please install jax.")
 
       attrs["xla"] = _xla
       parents = (base, GymnasiumEnvPoolMixin, EnvPoolMixin, gymnasium.Env)

--- a/envpool/python/xla_template.py
+++ b/envpool/python/xla_template.py
@@ -30,9 +30,9 @@ def _shape_with_layout(
 ) -> Tuple[xla_client.Shape, ...]:
   return tuple(
     xla_client.Shape
-    .array_shape(dtype, shape, tuple(range(len(shape) - 1, -1, -1)))
-    if len(shape) > 0 else xla_client.Shape.scalar_shape(dtype)
-    for shape, dtype in specs
+    .array_shape(dtype, shape, tuple(range(len(shape) -
+                                           1, -1, -1))) if len(shape) >
+    0 else xla_client.Shape.scalar_shape(dtype) for shape, dtype in specs
   )
 
 

--- a/envpool/toy_text/toy_text_test.py
+++ b/envpool/toy_text/toy_text_test.py
@@ -188,8 +188,8 @@ class _ToyTextEnvTest(absltest.TestCase):
         ref_obs, ref_rew, ref_terminated, ref_truncated, ref_info = ref.step(a)
         obs, rew, terminated, truncated, info = env.step(np.array([a], int))
         assert ref_obs == obs[0] and ref_rew == rew[
-          0] and ref_terminated == terminated[
-            0] and ref_truncated == truncated[0]
+          0] and ref_terminated == terminated[0] and ref_truncated == truncated[
+            0]
       assert ref_rew == 20 and ref_done
 
   def test_nchain(self) -> None:
@@ -225,8 +225,8 @@ class _ToyTextEnvTest(absltest.TestCase):
         ref_done = np.logical_or(ref_terminated, ref_truncated)
         obs, rew, terminated, truncated, info = env.step(np.array([a], int))
         assert ref_obs == obs[0] and ref_rew == rew[
-          0] and ref_terminated == terminated[
-            0] and ref_truncated == truncated[0]
+          0] and ref_terminated == terminated[0] and ref_truncated == truncated[
+            0]
         if ref_done:
           break
 

--- a/envpool/utils/image_process_test.cc
+++ b/envpool/utils/image_process_test.cc
@@ -21,16 +21,16 @@
 
 TEST(ImageProcessTest, Resize) {
   // shape
-  Array a(Spec<uint8_t>({4, 3, 1}));
-  Array b(Spec<uint8_t>({6, 7, 1}));
+  TArray a(Spec<uint8_t>({4, 3, 1}));
+  TArray b(Spec<uint8_t>({6, 7, 1}));
   Resize(a, &b);
   EXPECT_EQ(b.Shape(), std::vector<std::size_t>({6, 7, 1}));
   EXPECT_NE(a.Data(), b.Data());
   // same shape, no reference
-  Array a2(Spec<uint8_t>({4, 3, 2}));
+  TArray a2(Spec<uint8_t>({4, 3, 2}));
   a2(1, 0, 1) = 6;
   a2(3, 1, 0) = 4;
-  Array b2(Spec<uint8_t>({4, 3, 2}));
+  TArray b2(Spec<uint8_t>({4, 3, 2}));
   Resize(a2, &b2);
   EXPECT_EQ(a2.Shape(), b2.Shape());
   EXPECT_NE(a2.Data(), b2.Data());
@@ -40,8 +40,8 @@ TEST(ImageProcessTest, Resize) {
 
 TEST(ImageProcessTest, GrayScale) {
   // shape
-  Array a(Spec<uint8_t>({4, 3, 3}));
-  Array b(Spec<uint8_t>({4, 3, 1}));
+  TArray a(Spec<uint8_t>({4, 3, 3}));
+  TArray b(Spec<uint8_t>({4, 3, 1}));
   a(3, 2, 2) = 255;
   GrayScale(a, &b);
   EXPECT_EQ(static_cast<uint8_t>(b(3, 1)), 0);

--- a/envpool/vizdoom/vizdoom_env.h
+++ b/envpool/vizdoom/vizdoom_env.h
@@ -422,7 +422,7 @@ class VizdoomEnv : public Env<VizdoomEnvSpec> {
 
   void WriteState(float reward) {
     State state = Allocate();
-    std::vector<Array> state_array(state);
+    auto state_array = state.AllValues<Array>();
     state["reward"_] = reward;
     for (int i = 0; i < stack_num_; ++i) {
       state["obs"_]

--- a/examples/acme_examples/helpers.py
+++ b/examples/acme_examples/helpers.py
@@ -111,9 +111,7 @@ class AdderWrapper(Adder):
     # Record the next observation but leave the history buffer row open by
     # passing `partial_step=True`.
     self._adder._writer.append(
-      dict(
-        observation=timestep.observation, start_of_episode=timestep.first()
-      ),
+      dict(observation=timestep.observation, start_of_episode=timestep.first()),
       partial_step=True,
     )
     self._adder._add_first_called = True
@@ -211,13 +209,10 @@ class PPOBuilder(ppo.PPOBuilder):
 
       def _process(data):
         shape = data.shape
-        data = tf.transpose(
-          data, (0, 2, 1, *[i for i in range(3, len(shape))])
-        )
+        data = tf.transpose(data, (0, 2, 1, *[i for i in range(3, len(shape))]))
         data = tf.reshape(
-          data, (
-            self._config.batch_size, self._config.unroll_length + 1, *shape[3:]
-          )
+          data,
+          (self._config.batch_size, self._config.unroll_length + 1, *shape[3:])
         )
         return data
 

--- a/examples/cleanrl_examples/ppo_atari_envpool.py
+++ b/examples/cleanrl_examples/ppo_atari_envpool.py
@@ -530,9 +530,7 @@ if __name__ == "__main__":
     writer.add_scalar("losses/value_loss", v_loss.item(), global_step)
     writer.add_scalar("losses/policy_loss", pg_loss.item(), global_step)
     writer.add_scalar("losses/entropy", entropy_loss.item(), global_step)
-    writer.add_scalar(
-      "losses/old_approx_kl", old_approx_kl.item(), global_step
-    )
+    writer.add_scalar("losses/old_approx_kl", old_approx_kl.item(), global_step)
     writer.add_scalar("losses/approx_kl", approx_kl.item(), global_step)
     writer.add_scalar("losses/clipfrac", np.mean(clipfracs), global_step)
     writer.add_scalar("losses/explained_variance", explained_var, global_step)

--- a/examples/ppo_atari/ppo.py
+++ b/examples/ppo_atari/ppo.py
@@ -226,9 +226,7 @@ class Actor:
     stat = MovAvg()
     episodic_reward = 0
     for epoch in range(1, 1 + self.config.epoch):
-      with tqdm.trange(
-        self.config.step_per_epoch, desc=f'Epoch #{epoch}'
-      ) as t:
+      with tqdm.trange(self.config.step_per_epoch, desc=f'Epoch #{epoch}') as t:
         while t.n < self.config.step_per_epoch:
           # collect
           for _ in range(self.config.step_per_collect // self.config.waitnum):

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ envpool =
 based_on_style = yapf
 spaces_before_comment = 2
 dedent_closing_brackets = true
-column_limit = 79
+column_limit = 80
 continuation_indent_width = 2
 
 [flake8]
@@ -58,6 +58,7 @@ exclude =
     .git
 indent_size = 2
 extend-ignore = B024
+max-line-length = 80
 
 [pydocstyle]
 convention = google
@@ -66,7 +67,7 @@ convention = google
 profile = black
 multi_line_output = 3
 indent = 2
-line_length = 79
+line_length = 80
 
 [mypy]
 allow_redefinition = True


### PR DESCRIPTION
## Description

- Introduce `TArray` to have better type checking than `Array`.
- Fix several bugs that can be detected when test is run in dbg mode.

## Motivation and Context

`Array` was a temporary design which is very unsafe. e.g. in atari `state["done"_]` has integer type, while the return value of `game_over()` is subject to change in the thirdparty code. We need automatic type casting rather than manually checking them.

- [x] I have NOT raised an issue to propose this change ([required](https://envpool.readthedocs.io/en/latest/pages/contributing.html) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [x] TArray.
- [x] Utilities to cast `std::vector<Array>` to `Dict<Keys, TupleOfTArray>`.
- [x] Fix several bugs.
- [x] Replace `State`/`Action` in `Env` to be the type safe version.
- [x] Replace all uses of `Array` to `TArray`

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [x] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `make lint` (**required**)
- [x] I have ensured `make bazel-test` pass. (**required**)
