### PR TITLE
fix: removing .encode() in call to register_custom_call_target

### DIFF
--- a/envpool/python/xla_template.py
+++ b/envpool/python/xla_template.py
@@ -53,12 +53,10 @@ def _make_xla_function(
   out_specs = _normalize_specs(out_specs)
   cpu_capsule, gpu_capsule = capsules
   xla_client.register_custom_call_target(
-    f"{type(obj).__name__}_{id(obj)}_{name}_cpu".encode(),
-    cpu_capsule,
-    platform="cpu"
+    f"{type(obj).__name__}_{id(obj)}_{name}_cpu", cpu_capsule, platform="cpu"
   )
   xla_client.register_custom_call_target(
-    f"{type(obj).__name__}_{id(obj)}_{name}_gpu".encode(),
+    f"{type(obj).__name__}_{id(obj)}_{name}_gpu",
     gpu_capsule,
     platform="gpu",
   )


### PR DESCRIPTION
The function `envpool.python.xla_template._make_xla_function` wrongfully passes `bytes` instead of `str` for the `name` parameter when calling `xla_client.register_custom_call_target`. 

This leads to errors when calling `envs.xla()`. 

Removing `.encode()` fixes the issue.

