### PR TITLE
Update xla to use mlir rather than backend-specific-translations

### DIFF
--- a/envpool/python/xla_template.py
+++ b/envpool/python/xla_template.py
@@ -23,6 +23,7 @@ from jax import numpy as jnp
 from jax.core import ShapedArray
 from jax.interpreters import xla
 from jax.lib import xla_client
+from jax import interpreters
 
 
 def _shape_with_layout(
@@ -91,10 +92,10 @@ def _make_xla_function(
   prim.multiple_results = (len(out_specs) > 1)
   prim.def_impl(partial(xla.apply_primitive, prim))
   prim.def_abstract_eval(abstract)
-  xla.backend_specific_translations["cpu"][prim] = partial(
+  interpreters.mlir["cpu"][prim] = partial(
     translation, platform="cpu"
   )
-  xla.backend_specific_translations["gpu"][prim] = partial(
+  interpreters.mlir["gpu"][prim] = partial(
     translation, platform="gpu"
   )
 


### PR DESCRIPTION
## Description

Fixes https://github.com/sail-sg/envpool/issues/313

## Motivation and Context

EnvPool XLA doesn't work with Jax 0.4.29+

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)
