### PR TITLE
[envpool] migrate Bazel Qt rules in-tree

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -38,13 +38,9 @@ load("@local_config_qt//:local_qt.bzl", "local_qt_path")
 
 new_local_repository(
     name = "qt",
-    build_file = "@com_justbuchanan_rules_qt//:qt.BUILD",
+    build_file = "//third_party/qt:qt.BUILD",
     path = local_qt_path(),
 )
-
-load("@com_justbuchanan_rules_qt//tools:qt_toolchain.bzl", "register_qt_toolchains")
-
-register_qt_toolchains()
 
 load("//envpool:pip.bzl", pip_workspace = "workspace")
 

--- a/envpool/box2d/box2d_correctness_test.py
+++ b/envpool/box2d/box2d_correctness_test.py
@@ -31,13 +31,13 @@ class _Box2dEnvPoolCorrectnessTest(absltest.TestCase):
   def run_space_check(self, env0: gym.Env, env1: Any) -> None:
     """Check observation_space and action space."""
     obs0, obs1 = env0.observation_space, env1.observation_space
-    np.testing.assert_allclose(obs0.shape, obs1.shape)
+    self.assertEqual(obs0.shape, obs1.shape)
     act0, act1 = env0.action_space, env1.action_space
     if isinstance(act0, gym.spaces.Box):
       np.testing.assert_allclose(act0.low, act1.low)
       np.testing.assert_allclose(act0.high, act1.high)
     elif isinstance(act0, gym.spaces.Discrete):
-      np.testing.assert_allclose(act0.n, act1.n)
+      self.assertEqual(act0.n, act1.n)
 
   def test_bipedal_walker_space(self) -> None:
     env0 = gym.make("BipedalWalker-v3")

--- a/envpool/workspace0.bzl
+++ b/envpool/workspace0.bzl
@@ -162,16 +162,6 @@ def workspace():
 
     maybe(
         http_archive,
-        name = "com_justbuchanan_rules_qt",
-        sha256 = "29c1bf65369195d038eb5d3c923499fd229fa7ba947524dbdd9c48c91e1ee740",
-        strip_prefix = "bazel_rules_qt-89290cc7962d697c31b361a0f62141ca13d062d2",
-        urls = [
-            "https://github.com/justbuchanan/bazel_rules_qt/archive/89290cc7962d697c31b361a0f62141ca13d062d2.tar.gz",
-        ],
-    )
-
-    maybe(
-        http_archive,
         name = "glibc_version_header",
         sha256 = "57db74f933b7a9ea5c653498640431ce0e52aaef190d6bb586711ec4f8aa2b9e",
         strip_prefix = "glibc_version_header-0.1/version_headers/",

--- a/envpool/workspace1.bzl
+++ b/envpool/workspace1.bzl
@@ -15,9 +15,9 @@
 """EnvPool workspace initialization, load after workspace0."""
 
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
-load("@com_justbuchanan_rules_qt//:qt_configure.bzl", "qt_configure")
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 load("@rules_python//python:repositories.bzl", "python_register_multi_toolchains")
+load("//third_party/qt:qt_configure.bzl", "qt_configure")
 
 def workspace():
     """Configure pip requirements."""

--- a/third_party/qt/BUILD
+++ b/third_party/qt/BUILD
@@ -1,0 +1,18 @@
+# Copyright 2026 Garena Online Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exports_files([
+    "BUILD.local_qt.tpl",
+    "qt.BUILD",
+])

--- a/third_party/qt/BUILD.local_qt.tpl
+++ b/third_party/qt/BUILD.local_qt.tpl
@@ -1,0 +1,2 @@
+def local_qt_path():
+    return "%{path}"

--- a/third_party/qt/qt.BUILD
+++ b/third_party/qt/qt.BUILD
@@ -1,0 +1,38 @@
+# Copyright 2026 Garena Online Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "qt_core",
+    hdrs = glob(
+        ["QtCore/**"],
+        allow_empty = True,
+    ),
+    includes = ["."],
+    linkopts = ["-lQt5Core"],
+)
+
+cc_library(
+    name = "qt_gui",
+    hdrs = glob(
+        ["QtGui/**"],
+        allow_empty = True,
+    ),
+    includes = ["."],
+    linkopts = ["-lQt5Gui"],
+    deps = [":qt_core"],
+)

--- a/third_party/qt/qt_configure.bzl
+++ b/third_party/qt/qt_configure.bzl
@@ -1,0 +1,55 @@
+# Copyright 2026 Garena Online Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimal Linux-only Qt repository rule for EnvPool."""
+
+def _get_env_var(repository_ctx, name, default = None):
+    for key, value in repository_ctx.os.environ.items():
+        if name == key:
+            return value
+    return default
+
+def _qt_autoconf_impl(repository_ctx):
+    os_name = repository_ctx.os.name.lower()
+    if "linux" not in os_name:
+        fail("EnvPool Qt configure currently only supports Linux, got %s" % repository_ctx.os.name)
+
+    qt_path = "/usr/include/x86_64-linux-gnu/qt5"
+    if not repository_ctx.path(qt_path).exists:
+        qt_path = "/usr/include/qt"
+
+    env_qt_path = _get_env_var(repository_ctx, "BAZEL_RULES_QT_DIR")
+    if env_qt_path:
+        qt_path = env_qt_path
+        qt_path_with_include = qt_path + "/include"
+        if repository_ctx.path(qt_path_with_include).exists:
+            qt_path = qt_path_with_include
+
+    if not repository_ctx.path(qt_path).exists:
+        fail("Unable to locate Qt headers. Set BAZEL_RULES_QT_DIR or install qtbase5-dev.")
+
+    repository_ctx.file("BUILD", "# empty BUILD file so that bazel sees this as a valid package directory")
+    repository_ctx.template(
+        "local_qt.bzl",
+        repository_ctx.path(Label("//third_party/qt:BUILD.local_qt.tpl")),
+        {"%{path}": qt_path},
+    )
+
+qt_autoconf = repository_rule(
+    implementation = _qt_autoconf_impl,
+    configure = True,
+)
+
+def qt_configure():
+    qt_autoconf(name = "local_config_qt")


### PR DESCRIPTION
## Summary
- Problem: EnvPool still depends on the archived `bazel_rules_qt` repository even though the repo only needs a very small local Qt wrapper for Procgen, and the current branch also needed a small `box2d` typing fix to keep lint moving.
- Scope: Replaces the external `bazel_rules_qt` archive with repo-local Qt configure/build files used by Procgen, and includes a narrow `box2d_correctness_test.py` mypy fix. It does not change `threadpool`, `gym3_libenv`, or `bazel_clang_tidy` pins.
- Outcome: Bazel no longer fetches the archived Qt ruleset, Procgen continues to build against the local Linux Qt install, and `box2d_correctness_test.py` no longer trips mypy on scalar/shape comparisons.

This keeps the Qt dependency surface in-tree and removes a dead external Bazel rules dependency without changing Procgen's linked Qt libraries.

## Technical Details
- Approach: Add a minimal Linux-only `third_party/qt` repository rule that resolves the local Qt include directory and exposes the `qt_core`/`qt_gui` libraries EnvPool actually uses; then wire `WORKSPACE` and `workspace1.bzl` to those local rules.
- Code pointers:
  - `third_party/qt/qt_configure.bzl`: minimal local Qt repository rule that finds the Qt headers and templates `local_qt.bzl`
  - `third_party/qt/qt.BUILD`: repo-local `qt_core` / `qt_gui` Bazel targets used by Procgen
  - `WORKSPACE`: rewires `@qt` to the in-repo Qt BUILD file and drops the external Qt toolchain registration
  - `envpool/box2d/box2d_correctness_test.py`: swaps two `assert_allclose` calls for `assertEqual` to satisfy mypy on shape/discrete-cardinality checks
- Notes: upstream `justbuchanan/bazel_rules_qt` is archived and the previous pin was already at upstream head, so this is a replacement rather than a version bump.

## Test Plan
### Automated
- `make buildifier`: pass
- `make addlicense`: pass
- `make mypy`: pass
- `USE_BAZEL_VERSION=8.6.0 bazelisk test //envpool/procgen:procgen_env_test //envpool/procgen:procgen_test --enable_workspace --noenable_bzlmod --config=test --test_output=errors --nocache_test_results` on `dev-0`: pass
- `make bazel-test` on `dev-0`: `30 / 30 tests pass`
- `make lint` on `dev-0`: in progress; `flake8`, `py-format`, `clang-format`, `cpplint`, `buildifier`, `addlicense`, `mypy`, `docstyle`, and `spelling` have passed, and only the long-running `clang-tidy` tail remains
### Suggested Manual
- `make lint` on a Linux devbox: confirm the remaining `clang-tidy` tail finishes cleanly on the exact tree in this PR
