### PR TITLE
[examples] reset CleanRL Atari stats on truncation

### DIFF
--- a/examples/cleanrl_examples/ppo_atari_envpool.py
+++ b/examples/cleanrl_examples/ppo_atari_envpool.py
@@ -246,6 +246,8 @@ class RecordEpisodeStatistics(gym.Wrapper):
             observations, rewards, dones, infos = super(
                 RecordEpisodeStatistics, self
             ).step(action)
+            term = infos["terminated"]
+            trunc = infos["TimeLimit.truncated"]
         else:
             observations, rewards, term, trunc, infos = super(
                 RecordEpisodeStatistics, self
@@ -255,10 +257,10 @@ class RecordEpisodeStatistics(gym.Wrapper):
         self.episode_lengths += 1
         self.returned_episode_returns[:] = self.episode_returns
         self.returned_episode_lengths[:] = self.episode_lengths
-        all_lives_exhausted = infos["lives"] == 0
         if self.has_lives:
-            self.episode_returns *= 1 - all_lives_exhausted
-            self.episode_lengths *= 1 - all_lives_exhausted
+            episode_done = term + trunc
+            self.episode_returns *= 1 - episode_done
+            self.episode_lengths *= 1 - episode_done
         else:
             self.episode_returns *= 1 - dones
             self.episode_lengths *= 1 - dones


### PR DESCRIPTION
## Summary
- Problem: `RecordEpisodeStatistics` in the CleanRL Atari example carries episode return/length across time-limit truncation when `episodic_life=True`.
- Scope: Update the example wrapper so Atari stats reset on true episode boundaries (`terminated` or `truncated`) instead of only when lives reach zero.
- Outcome: Episode return and length no longer leak into the next timeout-delimited episode in the issue #299 repro.

This keeps the fix scoped to the example wrapper and aligns its bookkeeping with EnvPool's episode semantics under Atari time limits.

## Technical Details
- Approach: Reuse the existing `terminated` / `truncated` signals from the wrapped env and reset tracked stats on either condition in the `has_lives` path.
- Code pointers:
  - `examples/cleanrl_examples/ppo_atari_envpool.py`: derive `term` / `trunc` in both gym API branches and use them to clear `episode_returns` / `episode_lengths`.
- Notes: This intentionally does not change core EnvPool Atari runtime behavior; it only fixes the example-side statistics wrapper.

## Test Plan
### Automated
- `python3 -m py_compile examples/cleanrl_examples/ppo_atari_envpool.py`: passes
- `dev: source /tmp/envpool-issue299/venv/bin/activate && python /tmp/envpool_issue299_repro.py`: before fix the repro reported `episode=1 expected_return=10.0 recorded_return=20.0 expected_len=31 recorded_len=60`; after the fix it reports `episode=1 expected_return=10.0 recorded_return=10.0 expected_len=31 recorded_len=31`

### Suggested Manual
- `python3 examples/cleanrl_examples/ppo_atari_envpool.py ...`: run the Atari example with a short `max_episode_steps` setup and verify `info["r"]` / `info["l"]` reset after timeout boundaries
