### PR TITLE
[envpool] support per-env seed sequences

### DIFF
--- a/docs/content/python_interface.rst
+++ b/docs/content/python_interface.rst
@@ -17,8 +17,10 @@ batched environments:
   to ``num_envs``;
 * ``num_threads (int)``: the maximum thread number for executing the actual
   ``env.step``, default to ``batch_size``;
-* ``seed (int)``: set seed over all environments. The i-th environment seed
-  will be set with i+seed, default to ``42``;
+* ``seed (int | Sequence[int])``: set seed over all environments. If an int is
+  provided, the i-th environment seed will be set with i+seed. If a sequence
+  is provided, it must contain exactly one seed per environment. The default is
+  ``42``;
 * ``max_episode_steps (int)``: set the max steps in one episode. This value is
   env-specific (27000 steps or 27000 * 4 = 108000 frames in Atari for
   example);

--- a/docs/env/atari.rst
+++ b/docs/env/atari.rst
@@ -23,7 +23,9 @@ Options
   ``num_envs``;
 * ``num_threads (int)``: the maximum thread number for executing the actual
   ``env.step``, default to ``batch_size``;
-* ``seed (int)``: the environment seed, default to ``42``;
+* ``seed (int | Sequence[int])``: the environment seed. When a sequence is
+  provided, it must contain exactly one seed per environment. Default to
+  ``42``;
 * ``max_episode_steps (int)``: the maximum number of steps for one episode,
   default to ``27000``, which corresponds to 108000 frames or roughly 30
   minutes of game-play (`Hessel et al. 2018, Table 3

--- a/docs/env/procgen.rst
+++ b/docs/env/procgen.rst
@@ -14,7 +14,9 @@ Options
   ``num_envs``;
 * ``num_threads (int)``: the maximum thread number for executing the actual
   ``env.step``, default to ``batch_size``;
-* ``seed (int)``: the environment seed, default to ``42``;
+* ``seed (int | Sequence[int])``: the environment seed. When a sequence is
+  provided, it must contain exactly one seed per environment. Default to
+  ``42``;
 * ``max_episode_steps (int)``: the maximum number of steps for one episode,
   each procgen game has different timeout value;
 * ``channel_first (bool)``: whether to transpose the observation image to

--- a/docs/env/vizdoom.rst
+++ b/docs/env/vizdoom.rst
@@ -21,7 +21,9 @@ Options
   ``num_envs``;
 * ``num_threads (int)``: the maximum thread number for executing the actual
   ``env.step``, default to ``batch_size``;
-* ``seed (int)``: the environment seed, default to ``42``;
+* ``seed (int | Sequence[int])``: the environment seed. When a sequence is
+  provided, it must contain exactly one seed per environment. Default to
+  ``42``;
 * ``max_episode_steps (int)``: the maximum number of steps for one episode,
   default to ``525``;
 * ``img_height (int)``: the desired observation image height, default to

--- a/envpool/core/env.h
+++ b/envpool/core/env.h
@@ -88,11 +88,22 @@ class Env {
       Dict<typename EnvSpec::ActionKeys,
            typename SpecToTArray<typename EnvSpec::ActionSpec::Values>::Type>;
 
+  static int ResolveSeed(const EnvSpec& spec, int env_id) {
+    const auto& env_seed = spec.config["env_seed"_];
+    if (!env_seed.empty()) {
+      CHECK_EQ(env_seed.size(),
+               static_cast<std::size_t>(spec.config["num_envs"_]))
+          << "`env_seed` must contain exactly one seed for each env";
+      return env_seed.at(env_id);
+    }
+    return spec.config["seed"_] + env_id;
+  }
+
   Env(const EnvSpec& spec, int env_id)
       : max_num_players_(spec.config["max_num_players"_]),
         spec_(spec),
         env_id_(env_id),
-        seed_(spec.config["seed"_] + env_id),
+        seed_(ResolveSeed(spec, env_id)),
         gen_(seed_),
         is_single_player_(max_num_players_ == 1),
         action_specs_(spec.action_spec.template AllValues<ShapeSpec>()),

--- a/envpool/core/env_spec.h
+++ b/envpool/core/env_spec.h
@@ -23,12 +23,12 @@
 #include "envpool/core/array.h"
 #include "envpool/core/dict.h"
 
-auto common_config =
-    MakeDict("num_envs"_.Bind(1), "batch_size"_.Bind(0), "num_threads"_.Bind(0),
-             "max_num_players"_.Bind(1), "thread_affinity_offset"_.Bind(-1),
-             "base_path"_.Bind(std::string("envpool")), "seed"_.Bind(42),
-             "gym_reset_return_info"_.Bind(false),
-             "max_episode_steps"_.Bind(std::numeric_limits<int>::max()));
+auto common_config = MakeDict(
+    "num_envs"_.Bind(1), "batch_size"_.Bind(0), "num_threads"_.Bind(0),
+    "max_num_players"_.Bind(1), "thread_affinity_offset"_.Bind(-1),
+    "base_path"_.Bind(std::string("envpool")), "seed"_.Bind(42),
+    "env_seed"_.Bind(std::vector<int>{}), "gym_reset_return_info"_.Bind(false),
+    "max_episode_steps"_.Bind(std::numeric_limits<int>::max()));
 // Note: this action order is hardcoded in async_envpool Send function
 // and env ParseAction function for performance
 auto common_action_spec = MakeDict("env_id"_.Bind(Spec<int>({})),

--- a/envpool/dummy/dummy_py_envpool_test.py
+++ b/envpool/dummy/dummy_py_envpool_test.py
@@ -65,6 +65,7 @@ class _DummyEnvPoolTest(absltest.TestCase):
             "thread_affinity_offset",
             "base_path",
             "seed",
+            "env_seed",
             "gym_reset_return_info",
             "state_num",
             "action_num",
@@ -152,6 +153,48 @@ class _DummyEnvPoolTest(absltest.TestCase):
             )
             xla_failed = True
         self.assertTrue(xla_failed)
+
+    def test_env_seed_overrides_sequential_seeding(self) -> None:
+        conf = dict(
+            zip(
+                _DummyEnvSpec._config_keys,
+                _DummyEnvSpec._default_config_values,
+                strict=False,
+            )
+        )
+        conf["num_envs"] = 3
+        conf["batch_size"] = 3
+        conf["max_num_players"] = 1
+        conf["env_seed"] = [1, 3, 5]
+        env = _DummyEnvPool(_DummyEnvSpec(tuple(conf.values())))
+        env._reset(np.arange(3, dtype=np.int32))
+
+        action = (
+            np.arange(3, dtype=np.int32),
+            np.arange(3, dtype=np.int32),
+            np.zeros((3, 6), dtype=np.float64),
+            np.zeros((3,), dtype=np.int32),
+            np.zeros((3,), dtype=np.int32),
+        )
+
+        env._recv()  # consume reset output
+
+        env._send(action)
+        state = dict(zip(env._state_keys, env._recv(), strict=False))
+        np.testing.assert_array_equal(
+            state["done"],
+            np.array([True, False, False]),
+        )
+
+        env._send(action)
+        _ = env._recv()
+
+        env._send(action)
+        state = dict(zip(env._state_keys, env._recv(), strict=False))
+        np.testing.assert_array_equal(
+            state["done"],
+            np.array([True, True, False]),
+        )
 
 
 class _EnvPoolMixinRegressionTest(absltest.TestCase):

--- a/envpool/python/envpool.py
+++ b/envpool/python/envpool.py
@@ -25,6 +25,19 @@ from dm_env import TimeStep
 from .protocol import EnvPool, EnvSpec
 
 
+def _normalize_env_id(env_id: Any) -> Any:
+    """Normalize env_id while preserving traced arrays for XLA send paths."""
+    if isinstance(env_id, np.ndarray):
+        env_id = env_id.astype(np.int32, copy=False)
+    elif hasattr(env_id, "astype"):
+        env_id = env_id.astype(np.int32)
+    else:
+        env_id = np.asarray(env_id, dtype=np.int32)
+    if getattr(env_id, "ndim", 0) == 0:
+        env_id = env_id.reshape(1)
+    return env_id
+
+
 class EnvPoolMixin(ABC):
     """Mixin class for EnvPool, exposed to EnvPoolMeta."""
 
@@ -75,11 +88,10 @@ class EnvPoolMixin(ABC):
         self: EnvPool, adict: dict[str, Any]
     ) -> np.ndarray:
         """Fill in players.env_id for the simplified multiplayer API."""
-        env_id = np.asarray(adict["env_id"], dtype=np.int32)
-        if env_id.ndim == 0:
-            env_id = env_id.reshape(1)
+        env_id = _normalize_env_id(adict["env_id"])
         if self.config.get("max_num_players", 1) == 1:
             return env_id
+        env_id = np.asarray(env_id, dtype=np.int32)
         player_count = self._player_action_count(adict)
         if player_count is None or player_count == env_id.shape[0]:
             return env_id

--- a/envpool/python/gym_envpool.py
+++ b/envpool/python/gym_envpool.py
@@ -44,7 +44,10 @@ class GymEnvPoolMixin:
         return self._gym_action_space
 
 
-class GymEnvPoolMeta(ABCMeta, gym.Env.__class__):
+class GymEnvPoolMeta(
+    ABCMeta,
+    gym.Env.__class__,  # type: ignore[valid-type,misc,unused-ignore]
+):
     """Additional wrapper for EnvPool gym.Env API."""
 
     def __new__(cls: Any, name: str, parents: tuple, attrs: dict) -> Any:

--- a/envpool/registration.py
+++ b/envpool/registration.py
@@ -15,6 +15,7 @@
 
 import importlib
 import os
+from collections.abc import Sequence
 from typing import Any
 
 import gym
@@ -97,9 +98,22 @@ class EnvRegistry:
 
         # check arguments
         if "seed" in kwargs:  # Issue 214
-            INT_MAX = 2**31
-            assert -INT_MAX <= kwargs["seed"] < INT_MAX, (
-                f"Seed should be in range of int32, got {kwargs['seed']}"
+            if self._is_env_seed_sequence(kwargs["seed"]):
+                assert "env_seed" not in kwargs, (
+                    "Pass either `seed` as an int or seed list, or "
+                    "`env_seed`, but not both."
+                )
+                kwargs["env_seed"] = self._normalize_env_seed(
+                    kwargs["seed"],
+                    kwargs.get("num_envs", 1),
+                )
+                kwargs["seed"] = 0
+            else:
+                self._assert_int32_seed(kwargs["seed"])
+        if "env_seed" in kwargs:
+            kwargs["env_seed"] = self._normalize_env_seed(
+                kwargs["env_seed"],
+                kwargs.get("num_envs", 1),
             )
         if "num_envs" in kwargs:
             assert kwargs["num_envs"] >= 1
@@ -111,6 +125,37 @@ class EnvRegistry:
         spec_cls = getattr(importlib.import_module(import_path), spec_cls)
         config = spec_cls.gen_config(**kwargs)
         return spec_cls(config)
+
+    @staticmethod
+    def _assert_int32_seed(seed: Any) -> None:
+        INT_MAX = 2**31
+        assert -INT_MAX <= seed < INT_MAX, (
+            f"Seed should be in range of int32, got {seed}"
+        )
+
+    @staticmethod
+    def _is_env_seed_sequence(seed: Any) -> bool:
+        return (
+            isinstance(seed, Sequence) and not isinstance(seed, str | bytes)
+        ) or isinstance(seed, np.ndarray)
+
+    def _normalize_env_seed(self, seed: Any, num_envs: int) -> list[int]:
+        if isinstance(seed, np.ndarray):
+            assert seed.ndim == 1, (
+                "`seed` as an array must be 1-dimensional, "
+                f"got shape {seed.shape}"
+            )
+            seed = seed.tolist()
+        else:
+            seed = list(seed)
+        assert len(seed) == num_envs, (
+            "When `seed` is a sequence, its length must match `num_envs`, "
+            f"got len(seed) = {len(seed)} and num_envs = {num_envs}"
+        )
+        normalized_seed = [int(s) for s in seed]
+        for s in normalized_seed:
+            self._assert_int32_seed(s)
+        return normalized_seed
 
     def list_all_envs(self) -> list[str]:
         """Return all available task_id."""

--- a/envpool/vizdoom/vizdoom_env.h
+++ b/envpool/vizdoom/vizdoom_env.h
@@ -187,7 +187,7 @@ class VizdoomEnv : public Env<VizdoomEnvSpec> {
     if (!spec.config["wad_path"_].empty()) {
       dg_->setDoomScenarioPath(spec.config["wad_path"_]);
     }
-    dg_->setSeed(spec.config["seed"_]);
+    dg_->setSeed(seed_);
     dg_->setDoomMap(spec.config["map_id"_]);
 
     channel_ = dg_->getScreenChannels();


### PR DESCRIPTION
## Summary
- Problem: EnvPool only accepted scalar seeds and derived each env seed as `seed + env_id`, so callers could not assign explicit per-env seeds. The recent `players.env_id` inference logic also broke the single-player XLA send path by materializing traced `env_id` values through NumPy.
- Scope: Accept `seed` as an int or per-env sequence at the Python API, thread per-env seeds through core env creation and VizDoom, add dummy regression coverage, and preserve traced single-player `env_id` arrays in the Python action path. This does not change multiplayer inference rules or add extra `make_test` coverage.
- Outcome: `envpool.make(..., seed=[...])` now assigns one seed per env, VizDoom consumes the resolved per-env seed, and the Atari XLA API test passes again on dev.

This diff adds per-env seed sequences end-to-end and keeps the single-player XLA send path working.

## Technical Details
- Approach: Normalize sequence seeds in registration into an `env_seed` config vector, resolve each env instance seed from that vector when present, and defer NumPy conversion of `env_id` until multiplayer-only inference actually needs a NumPy array.
- Code pointers:
  - `envpool/registration.py`: validates `seed` and `env_seed` sequences, length, and int32 bounds before generating config.
  - `envpool/core/env.h`: resolves each env seed from `env_seed` instead of always using `seed + env_id`.
  - `envpool/python/envpool.py`: preserves traced single-player `env_id` arrays so JAX/XLA send paths avoid `TracerArrayConversionError`.
  - `envpool/dummy/dummy_py_envpool_test.py`: covers per-env seed override behavior in the dummy Python envpool path.
- Notes: `envpool/python/gym_envpool.py` now matches the existing gymnasium wrapper's mypy ignore so `make lint` no longer fails on the metaclass annotation.

## Test Plan
### Automated
- `python3 -m py_compile envpool/python/envpool.py`: passed
- `python3 -m py_compile envpool/python/gym_envpool.py`: passed
- `python3 -m mypy envpool/python/envpool.py`: passed
- `python3 -m mypy envpool/python/gym_envpool.py`: passed
- `python3 -m ruff check envpool/python/envpool.py`: passed
- `python3 -m ruff check envpool/python/gym_envpool.py`: passed
- `python3 -m ruff format --check envpool/python/envpool.py`: passed
- `python3 -m ruff format --check envpool/python/gym_envpool.py`: passed
- `bazel test //envpool/atari:atari_envpool_test --config=test --test_output=all --test_filter=_AtariEnvPoolTest.test_xla_api` on `dev`: passed
- `make bazel-test` on `dev`: passed

### Suggested Manual
- `python -c "import envpool; env = envpool.make_gym('Catch-v0', num_envs=3, seed=[3, 5, 7]); print(env.config['env_seed'])"`: verify explicit per-env seed sequences are accepted and preserved.
- `bazel test //envpool/atari:atari_envpool_test --config=test --test_filter=_AtariEnvPoolTest.test_xla_api`: recheck the focused XLA regression if you want the narrowest replay.
