### PR TITLE
[mujoco] support xml_file overrides across gym envs

### DIFF
--- a/envpool/mujoco/gym/ant.h
+++ b/envpool/mujoco/gym/ant.h
@@ -38,6 +38,7 @@ class AntEnvFns {
         "exclude_worldbody_contact_forces"_.Bind(false),
         "terminate_when_unhealthy"_.Bind(true),
         "exclude_current_positions_from_observation"_.Bind(true),
+        "xml_file"_.Bind(std::string("ant.xml")),
         "forward_reward_weight"_.Bind(1.0), "ctrl_cost_weight"_.Bind(0.5),
         "contact_cost_weight"_.Bind(5e-4), "healthy_reward"_.Bind(1.0),
         "healthy_z_min"_.Bind(0.2), "healthy_z_max"_.Bind(1.0),
@@ -89,7 +90,9 @@ class AntEnv : public Env<AntEnvSpec>, public MujocoEnv {
  public:
   AntEnv(const Spec& spec, int env_id)
       : Env<AntEnvSpec>(spec, env_id),
-        MujocoEnv(spec.config["base_path"_] + "/mujoco/assets_gym/ant.xml",
+        MujocoEnv(std::string(spec.config["base_path"_]) +
+                      "/mujoco/assets_gym/" +
+                      std::string(spec.config["xml_file"_]),
                   spec.config["frame_skip"_], spec.config["post_constraint"_],
                   spec.config["max_episode_steps"_]),
         id_torso_(mj_name2id(model_, mjOBJ_XBODY, "torso")),

--- a/envpool/mujoco/gym/half_cheetah.h
+++ b/envpool/mujoco/gym/half_cheetah.h
@@ -34,6 +34,7 @@ class HalfCheetahEnvFns {
     return MakeDict("reward_threshold"_.Bind(4800.0), "frame_skip"_.Bind(5),
                     "post_constraint"_.Bind(true),
                     "exclude_current_positions_from_observation"_.Bind(true),
+                    "xml_file"_.Bind(std::string("half_cheetah.xml")),
                     "ctrl_cost_weight"_.Bind(0.1),
                     "forward_reward_weight"_.Bind(1.0),
                     "reset_noise_scale"_.Bind(0.1));
@@ -70,10 +71,11 @@ class HalfCheetahEnv : public Env<HalfCheetahEnvSpec>, public MujocoEnv {
  public:
   HalfCheetahEnv(const Spec& spec, int env_id)
       : Env<HalfCheetahEnvSpec>(spec, env_id),
-        MujocoEnv(
-            spec.config["base_path"_] + "/mujoco/assets_gym/half_cheetah.xml",
-            spec.config["frame_skip"_], spec.config["post_constraint"_],
-            spec.config["max_episode_steps"_]),
+        MujocoEnv(std::string(spec.config["base_path"_]) +
+                      "/mujoco/assets_gym/" +
+                      std::string(spec.config["xml_file"_]),
+                  spec.config["frame_skip"_], spec.config["post_constraint"_],
+                  spec.config["max_episode_steps"_]),
         no_pos_(spec.config["exclude_current_positions_from_observation"_]),
         ctrl_cost_weight_(spec.config["ctrl_cost_weight"_]),
         forward_reward_weight_(spec.config["forward_reward_weight"_]),

--- a/envpool/mujoco/gym/hopper.h
+++ b/envpool/mujoco/gym/hopper.h
@@ -36,6 +36,7 @@ class HopperEnvFns {
         "post_constraint"_.Bind(true), "terminate_when_unhealthy"_.Bind(true),
         "legacy_healthy_reward"_.Bind(true),
         "exclude_current_positions_from_observation"_.Bind(true),
+        "xml_file"_.Bind(std::string("hopper.xml")),
         "ctrl_cost_weight"_.Bind(1e-3), "forward_reward_weight"_.Bind(1.0),
         "healthy_reward"_.Bind(1.0), "velocity_min"_.Bind(-10.0),
         "velocity_max"_.Bind(10.0), "healthy_state_min"_.Bind(-100.0),
@@ -77,7 +78,9 @@ class HopperEnv : public Env<HopperEnvSpec>, public MujocoEnv {
  public:
   HopperEnv(const Spec& spec, int env_id)
       : Env<HopperEnvSpec>(spec, env_id),
-        MujocoEnv(spec.config["base_path"_] + "/mujoco/assets_gym/hopper.xml",
+        MujocoEnv(std::string(spec.config["base_path"_]) +
+                      "/mujoco/assets_gym/" +
+                      std::string(spec.config["xml_file"_]),
                   spec.config["frame_skip"_], spec.config["post_constraint"_],
                   spec.config["max_episode_steps"_]),
         terminate_when_unhealthy_(spec.config["terminate_when_unhealthy"_]),

--- a/envpool/mujoco/gym/humanoid.h
+++ b/envpool/mujoco/gym/humanoid.h
@@ -39,6 +39,7 @@ class HumanoidEnvFns {
         "use_contact_force"_.Bind(false), "forward_reward_weight"_.Bind(1.25),
         "terminate_when_unhealthy"_.Bind(true),
         "exclude_current_positions_from_observation"_.Bind(true),
+        "xml_file"_.Bind(std::string("humanoid.xml")),
         "ctrl_cost_weight"_.Bind(0.1), "healthy_reward"_.Bind(5.0),
         "healthy_z_min"_.Bind(1.0), "healthy_z_max"_.Bind(2.0),
         "contact_cost_weight"_.Bind(5e-7), "contact_cost_max"_.Bind(10.0),
@@ -91,7 +92,9 @@ class HumanoidEnv : public Env<HumanoidEnvSpec>, public MujocoEnv {
  public:
   HumanoidEnv(const Spec& spec, int env_id)
       : Env<HumanoidEnvSpec>(spec, env_id),
-        MujocoEnv(spec.config["base_path"_] + "/mujoco/assets_gym/humanoid.xml",
+        MujocoEnv(std::string(spec.config["base_path"_]) +
+                      "/mujoco/assets_gym/" +
+                      std::string(spec.config["xml_file"_]),
                   spec.config["frame_skip"_], spec.config["post_constraint"_],
                   spec.config["max_episode_steps"_]),
         terminate_when_unhealthy_(spec.config["terminate_when_unhealthy"_]),

--- a/envpool/mujoco/gym/humanoid_standup.h
+++ b/envpool/mujoco/gym/humanoid_standup.h
@@ -36,6 +36,7 @@ class HumanoidStandupEnvFns {
                     "exclude_current_positions_from_observation"_.Bind(true),
                     "exclude_worldbody_observations"_.Bind(false),
                     "exclude_root_actuator_forces"_.Bind(false),
+                    "xml_file"_.Bind(std::string("humanoidstandup.xml")),
                     "ctrl_cost_weight"_.Bind(0.1),
                     "contact_cost_weight"_.Bind(5e-7),
                     "contact_cost_max"_.Bind(10.0), "healthy_reward"_.Bind(1.0),
@@ -83,8 +84,9 @@ class HumanoidStandupEnv : public Env<HumanoidStandupEnvSpec>,
  public:
   HumanoidStandupEnv(const Spec& spec, int env_id)
       : Env<HumanoidStandupEnvSpec>(spec, env_id),
-        MujocoEnv(spec.config["base_path"_] +
-                      "/mujoco/assets_gym/humanoidstandup.xml",
+        MujocoEnv(std::string(spec.config["base_path"_]) +
+                      "/mujoco/assets_gym/" +
+                      std::string(spec.config["xml_file"_]),
                   spec.config["frame_skip"_], spec.config["post_constraint"_],
                   spec.config["max_episode_steps"_]),
         no_pos_(spec.config["exclude_current_positions_from_observation"_]),

--- a/envpool/mujoco/gym/inverted_double_pendulum.h
+++ b/envpool/mujoco/gym/inverted_double_pendulum.h
@@ -35,6 +35,7 @@ class InvertedDoublePendulumEnvFns {
         "reward_threshold"_.Bind(9100.0), "frame_skip"_.Bind(5),
         "post_constraint"_.Bind(true), "healthy_reward"_.Bind(10.0),
         "reward_if_not_terminated"_.Bind(false), "constraint_obs_dim"_.Bind(3),
+        "xml_file"_.Bind(std::string("inverted_double_pendulum.xml")),
         "healthy_z_max"_.Bind(1.0), "observation_min"_.Bind(-10.0),
         "observation_max"_.Bind(10.0), "reset_noise_scale"_.Bind(0.1));
   }
@@ -71,8 +72,9 @@ class InvertedDoublePendulumEnv : public Env<InvertedDoublePendulumEnvSpec>,
  public:
   InvertedDoublePendulumEnv(const Spec& spec, int env_id)
       : Env<InvertedDoublePendulumEnvSpec>(spec, env_id),
-        MujocoEnv(spec.config["base_path"_] +
-                      "/mujoco/assets_gym/inverted_double_pendulum.xml",
+        MujocoEnv(std::string(spec.config["base_path"_]) +
+                      "/mujoco/assets_gym/" +
+                      std::string(spec.config["xml_file"_]),
                   spec.config["frame_skip"_], spec.config["post_constraint"_],
                   spec.config["max_episode_steps"_]),
         reward_if_not_terminated_(spec.config["reward_if_not_terminated"_]),

--- a/envpool/mujoco/gym/inverted_pendulum.h
+++ b/envpool/mujoco/gym/inverted_pendulum.h
@@ -34,6 +34,7 @@ class InvertedPendulumEnvFns {
     return MakeDict("reward_threshold"_.Bind(950.0), "frame_skip"_.Bind(2),
                     "post_constraint"_.Bind(true), "healthy_reward"_.Bind(1.0),
                     "reward_if_not_terminated"_.Bind(false),
+                    "xml_file"_.Bind(std::string("inverted_pendulum.xml")),
                     "healthy_z_min"_.Bind(-0.2), "healthy_z_max"_.Bind(0.2),
                     "reset_noise_scale"_.Bind(0.01));
   }
@@ -66,8 +67,9 @@ class InvertedPendulumEnv : public Env<InvertedPendulumEnvSpec>,
  public:
   InvertedPendulumEnv(const Spec& spec, int env_id)
       : Env<InvertedPendulumEnvSpec>(spec, env_id),
-        MujocoEnv(spec.config["base_path"_] +
-                      "/mujoco/assets_gym/inverted_pendulum.xml",
+        MujocoEnv(std::string(spec.config["base_path"_]) +
+                      "/mujoco/assets_gym/" +
+                      std::string(spec.config["xml_file"_]),
                   spec.config["frame_skip"_], spec.config["post_constraint"_],
                   spec.config["max_episode_steps"_]),
         reward_if_not_terminated_(spec.config["reward_if_not_terminated"_]),

--- a/envpool/mujoco/gym/mujoco_gym_deterministic_test.py
+++ b/envpool/mujoco/gym/mujoco_gym_deterministic_test.py
@@ -17,7 +17,7 @@ import numpy as np
 from absl.testing import absltest
 
 import envpool.mujoco.gym.registration  # noqa: F401
-from envpool.registration import make_gym
+from envpool.registration import make, make_gym, make_spec
 
 
 class _MujocoGymDeterministicTest(absltest.TestCase):
@@ -40,6 +40,15 @@ class _MujocoGymDeterministicTest(absltest.TestCase):
             self.assertTrue(np.all(obs_min <= obs2), obs2)
             self.assertTrue(np.all(obs0 <= obs_max), obs0)
             self.assertTrue(np.all(obs2 <= obs_max), obs2)
+
+    def test_half_cheetah_supports_xml_file(self) -> None:
+        xml_file = "half_cheetah_envpool.xml"
+        spec = make_spec("HalfCheetah-v5", xml_file=xml_file)
+        self.assertEqual(spec.config.xml_file, xml_file)
+
+        env = make("HalfCheetah-v5", env_type="gym", xml_file=xml_file)
+        env.reset()
+        env.close()
 
     def test_ant(self) -> None:
         self.check("Ant-v5")

--- a/envpool/mujoco/gym/reacher.h
+++ b/envpool/mujoco/gym/reacher.h
@@ -35,8 +35,10 @@ class ReacherEnvFns {
         "reward_threshold"_.Bind(-3.75), "frame_skip"_.Bind(2),
         "post_constraint"_.Bind(true), "ctrl_cost_weight"_.Bind(1.0),
         "reward_after_step"_.Bind(false), "obs_include_z_distance"_.Bind(true),
-        "dist_cost_weight"_.Bind(1.0), "reset_qpos_scale"_.Bind(0.1),
-        "reset_qvel_scale"_.Bind(0.005), "reset_goal_scale"_.Bind(0.2));
+        "dist_cost_weight"_.Bind(1.0),
+        "xml_file"_.Bind(std::string("reacher.xml")),
+        "reset_qpos_scale"_.Bind(0.1), "reset_qvel_scale"_.Bind(0.005),
+        "reset_goal_scale"_.Bind(0.2));
   }
   template <typename Config>
   static decltype(auto) StateSpec(const Config& conf) {
@@ -69,7 +71,9 @@ class ReacherEnv : public Env<ReacherEnvSpec>, public MujocoEnv {
  public:
   ReacherEnv(const Spec& spec, int env_id)
       : Env<ReacherEnvSpec>(spec, env_id),
-        MujocoEnv(spec.config["base_path"_] + "/mujoco/assets_gym/reacher.xml",
+        MujocoEnv(std::string(spec.config["base_path"_]) +
+                      "/mujoco/assets_gym/" +
+                      std::string(spec.config["xml_file"_]),
                   spec.config["frame_skip"_], spec.config["post_constraint"_],
                   spec.config["max_episode_steps"_]),
         id_fingertip_(mj_name2id(model_, mjOBJ_XBODY, "fingertip")),

--- a/envpool/mujoco/gym/swimmer.h
+++ b/envpool/mujoco/gym/swimmer.h
@@ -34,6 +34,7 @@ class SwimmerEnvFns {
     return MakeDict("reward_threshold"_.Bind(360.0), "frame_skip"_.Bind(4),
                     "post_constraint"_.Bind(true),
                     "exclude_current_positions_from_observation"_.Bind(true),
+                    "xml_file"_.Bind(std::string("swimmer.xml")),
                     "forward_reward_weight"_.Bind(1.0),
                     "ctrl_cost_weight"_.Bind(1e-4),
                     "reset_noise_scale"_.Bind(0.1));
@@ -72,7 +73,9 @@ class SwimmerEnv : public Env<SwimmerEnvSpec>, public MujocoEnv {
  public:
   SwimmerEnv(const Spec& spec, int env_id)
       : Env<SwimmerEnvSpec>(spec, env_id),
-        MujocoEnv(spec.config["base_path"_] + "/mujoco/assets_gym/swimmer.xml",
+        MujocoEnv(std::string(spec.config["base_path"_]) +
+                      "/mujoco/assets_gym/" +
+                      std::string(spec.config["xml_file"_]),
                   spec.config["frame_skip"_], spec.config["post_constraint"_],
                   spec.config["max_episode_steps"_]),
         no_pos_(spec.config["exclude_current_positions_from_observation"_]),


### PR DESCRIPTION
## Why
The original report in #295 was against `envpool==0.8.4` / `Ant-v4`, but the same root cause still exists on current `main` for supported Mujoco Gym tasks when `xml_file=...` is passed through registration.

## Summary
- add `xml_file` to the remaining Mujoco Gym env configs that still rejected the kwarg
- route those env constructors through `spec.config["xml_file"]` instead of hardcoded asset names
- keep the regression coverage narrow by extending the existing deterministic test with a `HalfCheetah-v5` smoke check

## Test plan
- `make bazel-test` on `dev` (`Executed 30 out of 30 tests: 30 tests pass.`)
- `make lint` on `dev` (current run has `ruff`, `ruff format --check`, `mypy`, `cpplint`, `clang-format`, `docstyle`, and `spelling` clean; `clang-tidy` long-tail build is still running)
