### PR TITLE
[atari] Fix frame_skip=1 max-pool ghosting

### DIFF
--- a/envpool/atari/atari_env.h
+++ b/envpool/atari/atari_env.h
@@ -190,12 +190,14 @@ class AtariEnv : public Env<AtariEnvSpec>, public RenderableEnv {
     done_ = false;
     int act = action["action"_];
     int skip_id = frame_skip_;
+    int pooled_frame_count = std::min(frame_skip_, 2);
     for (; skip_id > 0 && !done_; --skip_id) {
       reward += env_->act(action_set_[act]);
       done_ = env_->game_over();
-      if (skip_id <= 2) {  // put final two frames in to maxpool buffer
+      if (skip_id <= pooled_frame_count) {
         uint8_t* ale_screen_data = env_->getScreen().getArray();
-        auto* ptr = static_cast<uint8_t*>(maxpool_buf_[2 - skip_id].Data());
+        auto* ptr = static_cast<uint8_t*>(
+            maxpool_buf_[pooled_frame_count - skip_id].Data());
         if (gray_scale_) {
           env_->theOSystem->colourPalette().applyPaletteGrayscale(
               ptr, ale_screen_data, kRawSize);
@@ -206,7 +208,7 @@ class AtariEnv : public Env<AtariEnvSpec>, public RenderableEnv {
       }
     }
     // push the maxpool outcome to the stack_buf
-    PushStack(false, skip_id == 0);
+    PushStack(false, frame_skip_ > 1 && skip_id == 0);
     ++elapsed_step_;
     done_ |= (elapsed_step_ >= max_episode_steps_);
     if (episodic_life_ && 0 < env_->lives() && env_->lives() < lives_) {


### PR DESCRIPTION
## Summary
- Problem: `frame_skip=1` Atari steps were max-pooling the current frame with stale data from `maxpool_buf_[0]`, which leaves bright ball/paddle trails in RGB observations.
- Scope: Fix the Step() frame-buffer indexing and skip max-pool when there is only one frame to pool; no intended behavior change for `frame_skip>1`.
- Outcome: `frame_skip=1` now emits the current frame without stale-frame ghosting, while `frame_skip>=2` keeps the existing max-pool behavior.

This is a minimal Atari-only fix for the one-frame max-pool edge case.

## Technical Details
- Approach: Use `min(frame_skip_, 2)` as the number of pooled frames, write the sole frame into `maxpool_buf_[0]` when `frame_skip=1`, and only call `PushStack(..., maxpool=true)` when `frame_skip_ > 1`.
- Code pointers: `envpool/atari/atari_env.h`
- Notes: Reset-time stack fill is unchanged.

## Test Plan
### Automated
- `git diff --check`: passed
- `make bazel-pip-requirement-dev && USE_BAZEL_VERSION=8.6.0 BAZEL_RULES_QT_DIR=/opt/homebrew/opt/qt@5 bazelisk test --test_output=errors --config=test --spawn_strategy=local --action_env=PATH=/Users/jiayi/.virtualenvs/openai/lib/python3.12/site-packages/cmake/data/bin:/Users/jiayi/.virtualenvs/openai/bin:/opt/homebrew/bin:/bin:/usr/bin:/usr/local/bin //envpool/atari:atari_env_test`: passed

### Suggested Manual
- Run a `frame_skip=1` Atari RGB rollout and inspect a few frames/video to verify the ball and paddle no longer leave one-step trails.
