### PR TITLE
[packaging] Split runtime assets into envpool-assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,10 +154,10 @@ buildifier: buildifier-install
 # bazel build/test
 
 bazel-pip-requirement-dev:
-	cd third_party/pip_requirements && (cmp -s requirements.txt requirements-dev-lock.txt || cp -f requirements-dev-lock.txt requirements.txt)
+	cd third_party/pip_requirements && (cmp -s requirements.txt requirements-dev-lock.txt || (rm -f requirements.txt && cp -f requirements-dev-lock.txt requirements.txt))
 
 bazel-pip-requirement-release:
-	cd third_party/pip_requirements && (cmp -s requirements.txt requirements-release-lock.txt || cp -f requirements-release-lock.txt requirements.txt)
+	cd third_party/pip_requirements && (cmp -s requirements.txt requirements-release-lock.txt || (rm -f requirements.txt && cp -f requirements-release-lock.txt requirements.txt))
 
 clang-tidy: clang-tidy-install bazel-pip-requirement-dev
 	targets="$${CLANG_TIDY_TARGETS:-$$($(CLANG_TIDY_TARGET_RESOLVER) | tr '\n' ' ')}"; \
@@ -258,6 +258,7 @@ pypi-wheel: $(PYPI_WHEEL_PREREQS) bazel-release
 
 release-test1:
 	tmpdir=$$(python3 -c 'import tempfile; print(tempfile.mkdtemp(prefix="envpool-release-test-"))'); \
+	cd "$$tmpdir" && PYTHONPATH= python3 "$(CURDIR)/scripts/release_installed_wheel_smoke.py" --source-root "$(CURDIR)" && \
 	cd "$$tmpdir" && PYTHONPATH= python3 "$(CURDIR)/envpool/make_test.py"
 
 release-test2:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 - [x] [Atari games](https://envpool.readthedocs.io/en/latest/env/atari.html)
 - [x] [MuJoCo (Gymnasium)](https://envpool.readthedocs.io/en/latest/env/mujoco_gym.html)
-- [x] [MetaWorld](https://envpool.readthedocs.io/en/latest/env/metaworld.html)
 - [x] [Classic control RL envs](https://envpool.readthedocs.io/en/latest/env/classic_control.html): CartPole, MountainCar, Pendulum, Acrobot
 - [x] [Toy text RL envs](https://envpool.readthedocs.io/en/latest/env/toy_text.html): Catch, FrozenLake, Taxi, NChain, CliffWalking, Blackjack
 - [x] [ViZDoom single player](https://envpool.readthedocs.io/en/latest/env/vizdoom.html)
@@ -20,6 +19,7 @@
 - [x] [Procgen](https://envpool.readthedocs.io/en/latest/env/procgen.html)
 - [x] [Minigrid](https://envpool.readthedocs.io/en/latest/env/minigrid.html)
 - [x] [Highway](https://envpool.readthedocs.io/en/latest/env/highway.html)
+- [x] [MetaWorld](https://envpool.readthedocs.io/en/latest/env/metaworld.html)
 
 Here are EnvPool's several highlights:
 

--- a/envpool/__init__.py
+++ b/envpool/__init__.py
@@ -37,7 +37,7 @@ from envpool.registration import (
     register,
 )
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 __all__ = [
     "register",
     "make",

--- a/envpool/registration.py
+++ b/envpool/registration.py
@@ -14,6 +14,7 @@
 """Global env registry."""
 
 import importlib
+import importlib.util
 import os
 from collections.abc import Sequence
 from typing import Any, Literal, overload
@@ -26,7 +27,38 @@ from .python.protocol import (
     GymnasiumEnvPool,
 )
 
-base_path = os.path.abspath(os.path.dirname(__file__))
+
+def _package_dir(package_name: str) -> str | None:
+    spec = importlib.util.find_spec(package_name)
+    if spec is None or spec.submodule_search_locations is None:
+        return None
+    return os.path.abspath(next(iter(spec.submodule_search_locations)))
+
+
+def _has_local_assets(path: str) -> bool:
+    return all(
+        os.path.exists(os.path.join(path, asset_path))
+        for asset_path in (
+            "atari/roms",
+            "gfootball/assets",
+            "mujoco/assets_dmc",
+            "procgen/assets",
+            "vizdoom/maps",
+        )
+    )
+
+
+def _asset_base_path() -> str:
+    override = os.environ.get("ENVPOOL_ASSETS_PATH")
+    if override:
+        return os.path.abspath(override)
+    if _has_local_assets(package_base_path):
+        return package_base_path
+    return _package_dir("envpool_assets") or package_base_path
+
+
+package_base_path = os.path.abspath(os.path.dirname(__file__))
+base_path = _asset_base_path()
 
 
 class EnvRegistry:

--- a/envpool/vizdoom/registration.py
+++ b/envpool/vizdoom/registration.py
@@ -15,7 +15,7 @@
 
 import os
 
-from envpool.registration import base_path, register
+from envpool.registration import base_path, package_base_path, register
 
 maps_path = os.path.join(base_path, "vizdoom", "maps")
 
@@ -45,6 +45,7 @@ for game in _vizdoom_game_list() + ["vizdoom_custom"]:
         dm_cls="VizdoomDMEnvPool",
         gymnasium_cls="VizdoomGymnasiumEnvPool",
         cfg_path=cfg_path,
+        vzd_path=os.path.join(package_base_path, "vizdoom", "bin", "vizdoom"),
         wad_path=wad_path,
         max_episode_steps=525,
     )

--- a/envpool/vizdoom/vizdoom_env.h
+++ b/envpool/vizdoom/vizdoom_env.h
@@ -17,6 +17,7 @@
 #ifndef ENVPOOL_VIZDOOM_VIZDOOM_ENV_H_
 #define ENVPOOL_VIZDOOM_VIZDOOM_ENV_H_
 
+#include <cctype>
 #include <deque>
 #include <map>
 #include <memory>
@@ -32,9 +33,25 @@
 
 namespace vizdoom {
 
-std::string MergePath(const std::string& base_path,
-                      const std::string& file_path) {
-  if (file_path[0] == '/') {
+inline bool IsAbsolutePath(const std::string& file_path) {
+  if (file_path.empty()) {
+    return false;
+  }
+#if defined(_WIN32)
+  if (file_path[0] == '/' || file_path[0] == '\\') {
+    return true;
+  }
+  return file_path.size() >= 3 &&
+         std::isalpha(static_cast<unsigned char>(file_path[0])) &&
+         file_path[1] == ':' && (file_path[2] == '/' || file_path[2] == '\\');
+#else
+  return file_path[0] == '/';
+#endif
+}
+
+inline std::string MergePath(const std::string& base_path,
+                             const std::string& file_path) {
+  if (file_path.empty() || IsAbsolutePath(file_path)) {
     return file_path;
   }
   return base_path + "/" + file_path;

--- a/scripts/release_installed_wheel_smoke.py
+++ b/scripts/release_installed_wheel_smoke.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Smoke-check that release tests import installed wheels, including assets."""
+
+from __future__ import annotations
+
+import argparse
+from importlib.metadata import version
+from pathlib import Path
+
+from packaging.version import Version
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        required=True,
+        help="EnvPool source checkout that must not be imported.",
+    )
+    return parser.parse_args()
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def main() -> None:
+    """Check installed EnvPool and envpool-assets package wiring."""
+    args = _parse_args()
+    source_root = args.source_root.resolve()
+
+    import envpool_assets
+
+    import envpool
+    from envpool.registration import base_path, package_base_path
+
+    envpool_package = Path(envpool.__file__).resolve().parent
+    assets_package = Path(envpool_assets.asset_path()).resolve()
+
+    if _is_relative_to(envpool_package, source_root):
+        raise RuntimeError(
+            f"imported EnvPool from source tree: {envpool_package}"
+        )
+
+    asset_version = Version(version("envpool-assets"))
+    if not Version("0.1.0") <= asset_version < Version("0.2.0"):
+        raise RuntimeError(
+            f"unexpected envpool-assets version: {asset_version}"
+        )
+
+    if Path(base_path).resolve() != assets_package:
+        raise RuntimeError(
+            f"EnvPool asset base_path is {base_path}, expected {assets_package}"
+        )
+    if Path(package_base_path).resolve() != envpool_package:
+        raise RuntimeError(
+            "EnvPool package_base_path is "
+            f"{package_base_path}, expected {envpool_package}"
+        )
+
+    required_assets = [
+        assets_package / "atari/roms/pong.bin",
+        assets_package / "gfootball/assets/data",
+        assets_package / "mujoco/assets_dmc/cartpole.xml",
+        assets_package / "procgen/assets/platformer/playerBlue_dead.png",
+        assets_package / "vizdoom/bin/freedoom2.wad",
+        assets_package / "vizdoom/maps/basic.wad",
+    ]
+    missing = [path for path in required_assets if not path.exists()]
+    if missing:
+        raise RuntimeError(f"envpool-assets missing required files: {missing}")
+
+    required_package_files = [
+        envpool_package / "vizdoom/bin/vizdoom",
+        envpool_package / "vizdoom/bin/vizdoom.pk3",
+    ]
+    missing = [path for path in required_package_files if not path.exists()]
+    if missing:
+        raise RuntimeError(f"envpool wheel missing required files: {missing}")
+
+    print(f"envpool installed at {envpool_package}")
+    print(f"envpool-assets {asset_version} installed at {assets_package}")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = envpool
-version = 1.2.0
+version = 1.2.1
 author = "EnvPool Contributors"
 author_email = "sail@sea.com"
 description = "C++-based high-performance parallel environment execution engine (vectorized env) for general RL environments."
@@ -26,6 +26,7 @@ packages = find:
 python_requires = >=3.11
 install_requires =
     dm-env>=1.4
+    envpool-assets>=0.1.0,<0.2.0
     glfw>=2.10.0
     gymnasium>=0.26
     numpy>=1.19
@@ -43,16 +44,9 @@ envpool =
     **/*_envpool.so
     **/*_envpool.pyd
     **/*_envpool.pyd.dll
-    atari/roms/*.bin
     mujoco/*.so.*
-    mujoco/assets*/**/*.xml
-    mujoco/assets_dmc/dog_assets/*
-    mujoco/metaworld/assets/**/*
-    mujoco/robotics/assets/**/*
-    gfootball/assets/**/*
-    procgen/assets/**/*.png
-    vizdoom/bin/*
-    vizdoom/maps/*
+    vizdoom/bin/vizdoom
+    vizdoom/bin/vizdoom.pk3
 
 [mypy]
 allow_redefinition = True


### PR DESCRIPTION
## Description

This PR bumps the main package to `envpool==1.2.1` and moves EnvPool's platform-independent runtime assets out of the main `envpool` wheel and into the separately published `envpool-assets` wheel.

The runtime asset root now resolves in this order:

1. `ENVPOOL_ASSETS_PATH`, for explicit local overrides.
2. Local EnvPool package assets, when Bazel/source runfiles contain a complete generated asset tree.
3. The installed `envpool_assets` package.
4. The EnvPool package directory as the legacy fallback.

The main wheel still keeps platform-specific/runtime binaries that should stay with `envpool`, specifically the MuJoCo shared libraries and ViZDoom's executable plus `vizdoom.pk3`. ViZDoom map/WAD assets now resolve from the asset root while the platform binary resolves from the EnvPool package root.

This also hardens the Makefile pip lock copy targets by removing an ignored local `requirements.txt` symlink before copying a lockfile, so local release/dev target switches do not overwrite the symlink target.

Release smoke now explicitly verifies that tests are importing the installed `envpool` wheel from outside the source tree, that `envpool-assets>=0.1.0,<0.2.0` was installed as a dependency, and that EnvPool's runtime `base_path` points at `site-packages/envpool_assets`.

## Motivation and Context

The current macOS arm64 wheel is close to the PyPI 100 MB limit, and adding another asset-heavy environment would leave little room. Splitting stable, platform-independent assets into a pure `py3-none-any` package keeps the platform wheel small while preserving normal `pip install envpool` behavior through the new dependency.

The asset package version is intentionally independent from the EnvPool package version. `envpool==1.2.1` depends on the asset compatibility range `envpool-assets>=0.1.0,<0.2.0`; `envpool-assets==0.1.0` has been published from `Trinkle23897/envpool-assets` with its own optimized build workflow.

A local simulated split wheel, built from the previous monolithic release wheel plus this PR's Python/package metadata changes, was `24,626,751` bytes and passed the existing `scripts/check_wheel_size.py --limit-bytes 100000000` gate.

- [ ] I have raised an issue to propose this change ([required](https://envpool.readthedocs.io/en/latest/pages/contributing.html) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [x] Bump the main package version to `1.2.1` so the split wheels can be published.
- [x] Add `envpool-assets>=0.1.0,<0.2.0` as an install dependency.
- [x] Resolve runtime assets from override/local runfiles/installed asset package.
- [x] Remove platform-independent assets from main wheel package data.
- [x] Keep ViZDoom executable and `vizdoom.pk3` in the main platform wheel.
- [x] Add release smoke coverage that proves the installed wheel imports installed `envpool-assets` from outside the source tree.
- [x] Avoid local pip lock symlink corruption when switching Makefile release/dev requirements.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the code using `make lint` (**required**)
- [ ] I have ensured `make bazel-test` pass. (**required**)

## Validation

- `python3 -m py_compile envpool/__init__.py scripts/release_installed_wheel_smoke.py envpool/registration.py envpool/vizdoom/registration.py`
- `ruff format --check envpool/__init__.py scripts/release_installed_wheel_smoke.py envpool/registration.py envpool/vizdoom/registration.py`
- `ruff check envpool/__init__.py scripts/release_installed_wheel_smoke.py envpool/registration.py envpool/vizdoom/registration.py`
- `make ruff py-format`
- `git diff --check`
- `python3 -m pip install --no-deps --target /tmp/... envpool-assets==0.1.0` confirmed the independent asset version is available from PyPI and imports as `0.1.0`.
- `Trinkle23897/envpool-assets` workflow run `24425739587` built, optimized, smoke-tested, and published `envpool-assets==0.1.0`. The optimized local wheel size moved from `64,099,287` bytes to `62,428,874` bytes.
- Simulated split-wheel install smoke: installed the split main wheel into a temporary venv without explicitly installing assets, so pip resolved `envpool-assets==0.1.0` from the dependency range.
- `PATH=/tmp/envpool-release-venv.../bin:$PATH make release-test1` passed from a temporary venv. The new installed-wheel smoke confirmed `envpool` was imported from `site-packages/envpool`, `envpool-assets 0.1.0` was imported from `site-packages/envpool_assets`, EnvPool `base_path` pointed at the asset package, and `envpool/make_test.py` then ran 16 release tests successfully.

Blocked locally:

- `make pypi-wheel BAZELOPT="--action_env=PATH=$PATH"` did not reach compilation on this machine because Bazel's Java downloader failed fetching `bazel_features-v1.43.0.tar.gz` with `java.net.SocketException Operation not permitted`. GitHub Actions should validate the full release path.

