### PR TITLE
[mujoco] Fix EGL pixel env teardown crash

### DIFF
--- a/envpool/mujoco/BUILD
+++ b/envpool/mujoco/BUILD
@@ -664,6 +664,27 @@ py_test(
 )
 
 py_test(
+    name = "mujoco_egl_teardown_test",
+    size = "enormous",
+    srcs = ["mujoco_egl_teardown_test.py"],
+    imports = ["../.."],
+    deps = [
+        ":metaworld",
+        ":metaworld_registration",
+        ":mujoco_dmc",
+        ":mujoco_dmc_registration",
+        ":mujoco_gym",
+        ":mujoco_gym_registration",
+        ":mujoco_pixel_observation_test_utils",
+        ":myosuite",
+        ":myosuite_registration",
+        ":robotics",
+        ":robotics_registration",
+        requirement("absl-py"),
+    ],
+)
+
+py_test(
     name = "mujoco_dmc_pixel_observation_test",
     size = "enormous",
     srcs = ["dmc/mujoco_dmc_pixel_observation_test.py"],
@@ -729,6 +750,7 @@ py_test(
 test_suite(
     name = "mujoco_pixel_observation_test",
     tests = [
+        ":mujoco_egl_teardown_test",
         ":mujoco_dmc_pixel_observation_test",
         ":mujoco_gym_pixel_observation_test",
         ":robotics_pixel_observation_test",

--- a/envpool/mujoco/mujoco_egl_teardown_test.py
+++ b/envpool/mujoco/mujoco_egl_teardown_test.py
@@ -23,8 +23,16 @@ _EGL_TEARDOWN_CASES = (
     ("dmc", "envpool.mujoco.dmc.registration", "WalkerWalk-v1"),
     ("gym", "envpool.mujoco.gym.registration", "Walker2d-v4"),
     ("robotics", "envpool.mujoco.robotics.registration", "FetchReach-v4"),
-    ("metaworld", "envpool.mujoco.metaworld.registration", "MetaWorld/Reach-v3"),
-    ("myosuite", "envpool.mujoco.myosuite.registration", "myoFingerReachFixed-v0"),
+    (
+        "metaworld",
+        "envpool.mujoco.metaworld.registration",
+        "MetaWorld/Reach-v3",
+    ),
+    (
+        "myosuite",
+        "envpool.mujoco.myosuite.registration",
+        "myoFingerReachFixed-v0",
+    ),
 )
 
 
@@ -33,9 +41,7 @@ class MujocoEglTeardownTest(absltest.TestCase):
 
     def test_pixel_env_teardown_exits_cleanly_for_all_gl_families(self) -> None:
         """All native MuJoCo pixel families should exit cleanly under EGL."""
-        assert_egl_pixel_env_teardown_exits_cleanly(
-            self, _EGL_TEARDOWN_CASES
-        )
+        assert_egl_pixel_env_teardown_exits_cleanly(self, _EGL_TEARDOWN_CASES)
 
 
 if __name__ == "__main__":

--- a/envpool/mujoco/mujoco_egl_teardown_test.py
+++ b/envpool/mujoco/mujoco_egl_teardown_test.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Garena Online Private Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""EGL teardown regression coverage for native MuJoCo pixel envs."""
+
+from absl.testing import absltest
+
+from envpool.mujoco.pixel_observation_test_utils import (
+    assert_egl_pixel_env_teardown_exits_cleanly,
+)
+
+_EGL_TEARDOWN_CASES = (
+    ("dmc", "envpool.mujoco.dmc.registration", "WalkerWalk-v1"),
+    ("gym", "envpool.mujoco.gym.registration", "Walker2d-v4"),
+    ("robotics", "envpool.mujoco.robotics.registration", "FetchReach-v4"),
+    ("metaworld", "envpool.mujoco.metaworld.registration", "MetaWorld/Reach-v3"),
+    ("myosuite", "envpool.mujoco.myosuite.registration", "myoFingerReachFixed-v0"),
+)
+
+
+class MujocoEglTeardownTest(absltest.TestCase):
+    """Teardown tests for MuJoCo env families backed by native GL rendering."""
+
+    def test_pixel_env_teardown_exits_cleanly_for_all_gl_families(self) -> None:
+        """All native MuJoCo pixel families should exit cleanly under EGL."""
+        assert_egl_pixel_env_teardown_exits_cleanly(
+            self, _EGL_TEARDOWN_CASES
+        )
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/envpool/mujoco/myosuite/myosuite_oracle_probe.py
+++ b/envpool/mujoco/myosuite/myosuite_oracle_probe.py
@@ -33,7 +33,7 @@ import sys
 import tempfile
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 # MyoSuite projects normalized muscle actions through np.exp(float32). NumPy's
 # optional x86 SIMD kernels and its scalar kernel differ by single-ULP amounts,
@@ -343,7 +343,7 @@ def _configure_windows_mujoco_renderer() -> None:
     window_proc = wndproc(user32.DefWindowProcW)
 
     class _WndClass(ctypes.Structure):
-        _fields_ = [
+        _fields_: ClassVar[Any] = [
             ("style", wintypes.UINT),
             ("lpfnWndProc", wndproc),
             ("cbClsExtra", ctypes.c_int),
@@ -357,7 +357,7 @@ def _configure_windows_mujoco_renderer() -> None:
         ]
 
     class _PixelFormatDescriptor(ctypes.Structure):
-        _fields_ = [
+        _fields_: ClassVar[Any] = [
             ("nSize", wintypes.WORD),
             ("nVersion", wintypes.WORD),
             ("dwFlags", wintypes.DWORD),

--- a/envpool/mujoco/offscreen_renderer.cc
+++ b/envpool/mujoco/offscreen_renderer.cc
@@ -369,7 +369,7 @@ class EglContext final : public GlContext {
       throw std::runtime_error("failed to initialize EGL");
     }
     eglReleaseThread();
-    EGLDisplay display = display_->get();
+    EGLDisplay display = display_->Get();
     EGLConfig config = nullptr;
     EGLint num_configs = 0;
     if (eglChooseConfig(display, config_attribs.data(), &config, 1,
@@ -398,7 +398,7 @@ class EglContext final : public GlContext {
 
   ~EglContext() override {
     if (display_ != nullptr) {
-      EGLDisplay display = display_->get();
+      EGLDisplay display = display_->Get();
       eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
       if (context_ != EGL_NO_CONTEXT) {
         eglDestroyContext(display, context_);
@@ -411,14 +411,14 @@ class EglContext final : public GlContext {
   }
 
   void MakeCurrent() override {
-    if (eglMakeCurrent(display_->get(), surface_, surface_, context_) !=
+    if (eglMakeCurrent(display_->Get(), surface_, surface_, context_) !=
         EGL_TRUE) {
       throw std::runtime_error("failed to make EGL context current");
     }
   }
 
   void ClearCurrent() override {
-    if (eglMakeCurrent(display_->get(), EGL_NO_SURFACE, EGL_NO_SURFACE,
+    if (eglMakeCurrent(display_->Get(), EGL_NO_SURFACE, EGL_NO_SURFACE,
                        EGL_NO_CONTEXT) != EGL_TRUE) {
       throw std::runtime_error("failed to clear EGL context");
     }
@@ -437,7 +437,7 @@ class EglContext final : public GlContext {
       }
     }
 
-    EGLDisplay get() const { return display_; }
+    EGLDisplay Get() const { return display_; }
 
    private:
     EGLDisplay display_{EGL_NO_DISPLAY};
@@ -623,7 +623,8 @@ OffscreenRenderer::~OffscreenRenderer() {
   try {
     gl_context_->MakeCurrent();
     made_current = true;
-  } catch (const std::exception&) {
+  } catch (const std::exception& error) {
+    static_cast<void>(error);
     // Destructors must not throw during Python/interpreter shutdown. If the GL
     // context is already unavailable, free CPU-side scene state and let process
     // teardown reclaim the backend resources.
@@ -635,7 +636,8 @@ OffscreenRenderer::~OffscreenRenderer() {
   if (made_current) {
     try {
       gl_context_->ClearCurrent();
-    } catch (const std::exception&) {
+    } catch (const std::exception& error) {
+      static_cast<void>(error);
       // Preserve no-throw destructor semantics.
     }
   }

--- a/envpool/mujoco/offscreen_renderer.cc
+++ b/envpool/mujoco/offscreen_renderer.cc
@@ -364,64 +364,61 @@ class EglContext final : public GlContext {
         EGL_WIDTH, 1, EGL_HEIGHT, 1, EGL_NONE,
     };
 
-    display_ = CreateDisplay();
-    if (display_ == EGL_NO_DISPLAY) {
+    display_ = AcquireDisplay();
+    if (display_ == nullptr) {
       throw std::runtime_error("failed to initialize EGL");
     }
     eglReleaseThread();
+    EGLDisplay display = display_->get();
     EGLConfig config = nullptr;
     EGLint num_configs = 0;
-    if (eglChooseConfig(display_, config_attribs.data(), &config, 1,
+    if (eglChooseConfig(display, config_attribs.data(), &config, 1,
                         &num_configs) != EGL_TRUE ||
         num_configs < 1) {
-      eglTerminate(display_);
-      display_ = EGL_NO_DISPLAY;
+      display_.reset();
       throw std::runtime_error("failed to choose EGL config");
     }
     if (eglBindAPI(EGL_OPENGL_API) != EGL_TRUE) {
-      eglTerminate(display_);
-      display_ = EGL_NO_DISPLAY;
+      display_.reset();
       throw std::runtime_error("failed to bind EGL OpenGL API");
     }
-    surface_ =
-        eglCreatePbufferSurface(display_, config, pbuffer_attribs.data());
+    surface_ = eglCreatePbufferSurface(display, config, pbuffer_attribs.data());
     if (surface_ == EGL_NO_SURFACE) {
-      eglTerminate(display_);
-      display_ = EGL_NO_DISPLAY;
+      display_.reset();
       throw std::runtime_error("failed to create EGL pbuffer surface");
     }
-    context_ = eglCreateContext(display_, config, EGL_NO_CONTEXT, nullptr);
+    context_ = eglCreateContext(display, config, EGL_NO_CONTEXT, nullptr);
     if (context_ == EGL_NO_CONTEXT) {
-      eglDestroySurface(display_, surface_);
+      eglDestroySurface(display, surface_);
       surface_ = EGL_NO_SURFACE;
-      eglTerminate(display_);
-      display_ = EGL_NO_DISPLAY;
+      display_.reset();
       throw std::runtime_error("failed to create EGL context");
     }
   }
 
   ~EglContext() override {
-    if (display_ != EGL_NO_DISPLAY) {
-      eglMakeCurrent(display_, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    if (display_ != nullptr) {
+      EGLDisplay display = display_->get();
+      eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
       if (context_ != EGL_NO_CONTEXT) {
-        eglDestroyContext(display_, context_);
+        eglDestroyContext(display, context_);
       }
       if (surface_ != EGL_NO_SURFACE) {
-        eglDestroySurface(display_, surface_);
+        eglDestroySurface(display, surface_);
       }
-      eglTerminate(display_);
       eglReleaseThread();
     }
   }
 
   void MakeCurrent() override {
-    if (eglMakeCurrent(display_, surface_, surface_, context_) != EGL_TRUE) {
+    if (eglMakeCurrent(display_->get(), surface_, surface_, context_) !=
+        EGL_TRUE) {
       throw std::runtime_error("failed to make EGL context current");
     }
   }
 
   void ClearCurrent() override {
-    if (eglMakeCurrent(display_, EGL_NO_SURFACE, EGL_NO_SURFACE,
+    if (eglMakeCurrent(display_->get(), EGL_NO_SURFACE, EGL_NO_SURFACE,
                        EGL_NO_CONTEXT) != EGL_TRUE) {
       throw std::runtime_error("failed to clear EGL context");
     }
@@ -429,6 +426,23 @@ class EglContext final : public GlContext {
   }
 
  private:
+  class DisplayHandle {
+   public:
+    explicit DisplayHandle(EGLDisplay display) : display_(display) {}
+
+    ~DisplayHandle() {
+      if (display_ != EGL_NO_DISPLAY) {
+        eglTerminate(display_);
+        eglReleaseThread();
+      }
+    }
+
+    EGLDisplay get() const { return display_; }
+
+   private:
+    EGLDisplay display_{EGL_NO_DISPLAY};
+  };
+
   static EGLDisplay TryInitializeDisplay(EGLDisplay display) {
     if (display == EGL_NO_DISPLAY) {
       return EGL_NO_DISPLAY;
@@ -502,7 +516,7 @@ class EglContext final : public GlContext {
   }
 #endif
 
-  static EGLDisplay CreateDisplay() {
+  static EGLDisplay CreateRawDisplay() {
 #if defined(ENVPOOL_HAS_EGL_DEVICE_EXT)
     EGLDisplay display = TryInitializeDeviceDisplay();
     if (display != EGL_NO_DISPLAY) {
@@ -512,7 +526,25 @@ class EglContext final : public GlContext {
     return TryInitializeDisplay(eglGetDisplay(EGL_DEFAULT_DISPLAY));
   }
 
-  EGLDisplay display_{EGL_NO_DISPLAY};
+  static std::shared_ptr<DisplayHandle> AcquireDisplay() {
+    static std::mutex mutex;
+    static std::weak_ptr<DisplayHandle> weak_display;
+
+    std::lock_guard<std::mutex> lock(mutex);
+    std::shared_ptr<DisplayHandle> display = weak_display.lock();
+    if (display != nullptr) {
+      return display;
+    }
+    EGLDisplay raw_display = CreateRawDisplay();
+    if (raw_display == EGL_NO_DISPLAY) {
+      return nullptr;
+    }
+    display = std::make_shared<DisplayHandle>(raw_display);
+    weak_display = display;
+    return display;
+  }
+
+  std::shared_ptr<DisplayHandle> display_;
   EGLContext context_{EGL_NO_CONTEXT};
   EGLSurface surface_{EGL_NO_SURFACE};
 };
@@ -587,10 +619,26 @@ OffscreenRenderer::~OffscreenRenderer() {
   if (!initialized_) {
     return;
   }
-  gl_context_->MakeCurrent();
-  mjr_freeContext(&context_);
+  bool made_current = false;
+  try {
+    gl_context_->MakeCurrent();
+    made_current = true;
+  } catch (const std::exception&) {
+    // Destructors must not throw during Python/interpreter shutdown. If the GL
+    // context is already unavailable, free CPU-side scene state and let process
+    // teardown reclaim the backend resources.
+  }
+  if (made_current) {
+    mjr_freeContext(&context_);
+  }
   mjv_freeScene(&scene_);
-  gl_context_->ClearCurrent();
+  if (made_current) {
+    try {
+      gl_context_->ClearCurrent();
+    } catch (const std::exception&) {
+      // Preserve no-throw destructor semantics.
+    }
+  }
 }
 
 void OffscreenRenderer::Initialize(const mjModel* model) {

--- a/envpool/mujoco/pixel_observation_test_utils.py
+++ b/envpool/mujoco/pixel_observation_test_utils.py
@@ -13,6 +13,11 @@
 # limitations under the License.
 """Shared helpers for native MuJoCo pixel-observation tests."""
 
+import os
+import platform
+import subprocess
+import sys
+from collections.abc import Sequence
 from typing import Any
 
 import gymnasium
@@ -20,6 +25,7 @@ import numpy as np
 from absl import logging
 from absl.testing import absltest
 
+from envpool.python import glfw_context as envpool_glfw_context
 from envpool.python.glfw_context import preload_windows_gl_dlls
 from envpool.registration import make_gymnasium, make_spec, registry
 
@@ -28,6 +34,10 @@ preload_windows_gl_dlls(strict=True)
 RENDER_WIDTH = 64
 RENDER_HEIGHT = 48
 NUM_STEPS = 3
+EGL_TEARDOWN_RENDER_WIDTH = 84
+EGL_TEARDOWN_RENDER_HEIGHT = 84
+EGL_TEARDOWN_FRAME_STACK = 3
+EglTeardownCase = tuple[str, str, str]
 
 
 def task_ids_for_import_path(import_path: str) -> list[str]:
@@ -239,3 +249,73 @@ def assert_tasks_align_with_render_for_three_steps(
                     _assert_pixels_match(obs, render)
             finally:
                 env.close()
+
+
+def assert_egl_pixel_env_teardown_exits_cleanly(
+    test: absltest.TestCase,
+    cases: Sequence[EglTeardownCase],
+) -> None:
+    """Checks EGL pixel envs from multiple families can exit cleanly.
+
+    The subprocess intentionally keeps envs alive until interpreter shutdown:
+    issue #401 happens in teardown, after the rollout itself has succeeded.
+    """
+    if platform.system() != "Linux":
+        test.skipTest("EGL teardown regression is Linux-specific.")
+    env = dict(os.environ)
+    env["MUJOCO_GL"] = "egl"
+    env.setdefault("EGL_PLATFORM", "surfaceless")
+
+    package_parent = os.path.dirname(
+        os.path.dirname(os.path.dirname(envpool_glfw_context.__file__))
+    )
+    python_paths = [package_parent] + [
+        path for path in sys.path if path and path != package_parent
+    ]
+    python_path = os.pathsep.join(python_paths)
+    if env.get("PYTHONPATH"):
+        python_path = f"{python_path}{os.pathsep}{env['PYTHONPATH']}"
+    env["PYTHONPATH"] = python_path
+
+    code = f"""
+import importlib
+import sys
+
+sys.path.insert(0, {package_parent!r})
+sys.modules.pop("envpool", None)
+from envpool.registration import make
+
+envs = []
+for label, registration_module, task_id in {tuple(cases)!r}:
+    importlib.import_module(registration_module)
+    pixels = make(
+        task_id,
+        env_type="gymnasium",
+        num_envs=2,
+        from_pixels=True,
+        frame_stack={EGL_TEARDOWN_FRAME_STACK},
+        render_width={EGL_TEARDOWN_RENDER_WIDTH},
+        render_height={EGL_TEARDOWN_RENDER_HEIGHT},
+    )
+    obs, info = pixels.reset()
+    assert obs.shape == (
+        2,
+        {3 * EGL_TEARDOWN_FRAME_STACK},
+        {EGL_TEARDOWN_RENDER_HEIGHT},
+        {EGL_TEARDOWN_RENDER_WIDTH},
+    ), (label, task_id, obs.shape)
+    envs.append(pixels)
+    print("successful", label, task_id)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    test.assertEqual(
+        result.returncode,
+        0,
+        msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+    )

--- a/envpool/mujoco/pixel_observation_test_utils.py
+++ b/envpool/mujoco/pixel_observation_test_utils.py
@@ -37,6 +37,7 @@ NUM_STEPS = 3
 EGL_TEARDOWN_RENDER_WIDTH = 84
 EGL_TEARDOWN_RENDER_HEIGHT = 84
 EGL_TEARDOWN_FRAME_STACK = 3
+EGL_TEARDOWN_SUBPROCESS_TIMEOUT_SECONDS = 180
 EglTeardownCase = tuple[str, str, str]
 
 
@@ -307,13 +308,21 @@ for label, registration_module, task_id in {tuple(cases)!r}:
     envs.append(pixels)
     print("successful", label, task_id)
 """
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=EGL_TEARDOWN_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        test.fail(
+            "EGL teardown subprocess timed out after "
+            f"{EGL_TEARDOWN_SUBPROCESS_TIMEOUT_SECONDS} seconds.\n"
+            f"stdout:\n{exc.stdout or ''}\nstderr:\n{exc.stderr or ''}"
+        )
     test.assertEqual(
         result.returncode,
         0,

--- a/envpool/mujoco/pixel_observation_test_utils.py
+++ b/envpool/mujoco/pixel_observation_test_utils.py
@@ -89,6 +89,14 @@ def _assert_nested_equal(lhs: Any, rhs: Any) -> None:
     np.testing.assert_allclose(np.asarray(lhs), np.asarray(rhs))
 
 
+def _subprocess_output_to_text(output: str | bytes | None) -> str:
+    if output is None:
+        return ""
+    if isinstance(output, bytes):
+        return output.decode(errors="replace")
+    return output
+
+
 def assert_make_spec_exposes_bchw_pixel_specs(
     test: absltest.TestCase, import_path: str
 ) -> None:
@@ -318,10 +326,12 @@ for label, registration_module, task_id in {tuple(cases)!r}:
             timeout=EGL_TEARDOWN_SUBPROCESS_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired as exc:
+        stdout = _subprocess_output_to_text(exc.stdout)
+        stderr = _subprocess_output_to_text(exc.stderr)
         test.fail(
             "EGL teardown subprocess timed out after "
             f"{EGL_TEARDOWN_SUBPROCESS_TIMEOUT_SECONDS} seconds.\n"
-            f"stdout:\n{exc.stdout or ''}\nstderr:\n{exc.stderr or ''}"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
         )
     test.assertEqual(
         result.returncode,

--- a/envpool/procgen/procgen_test.py
+++ b/envpool/procgen/procgen_test.py
@@ -38,6 +38,7 @@ class _ProcgenEnvPoolTest(absltest.TestCase):
     ) -> None:
         if ProcgenGym3Env is None:
             self.skipTest("upstream procgen is not installed")
+        assert ProcgenGym3Env is not None
 
         logging.info(f"procgen oracle check for {task_id}")
         envpool_env = make_gym(

--- a/envpool/procgen/procgen_test.py
+++ b/envpool/procgen/procgen_test.py
@@ -14,6 +14,8 @@
 """Unit tests for Procgen environments."""
 
 # import cv2
+from typing import Any, cast
+
 import numpy as np
 from absl import logging
 from absl.testing import absltest
@@ -37,8 +39,11 @@ class _ProcgenEnvPoolTest(absltest.TestCase):
         total: int = 200,
     ) -> None:
         if ProcgenGym3Env is None:
-            self.skipTest("upstream procgen is not installed")
-        assert ProcgenGym3Env is not None
+            self.skipTest(
+                "optional upstream procgen oracle is not installed; "
+                "native Procgen checks still run"
+            )
+        procgen_env_cls = cast(Any, ProcgenGym3Env)
 
         logging.info(f"procgen oracle check for {task_id}")
         envpool_env = make_gym(
@@ -52,7 +57,7 @@ class _ProcgenEnvPoolTest(absltest.TestCase):
         procgen_env = None
         rng = np.random.default_rng(seed)
         try:
-            procgen_env = ProcgenGym3Env(
+            procgen_env = procgen_env_cls(
                 num=1,
                 env_name=env_name,
                 distribution_mode=distribution[dist_value].lower(),


### PR DESCRIPTION
## Description

This fixes the EGL teardown crash reported in issue #401 for native MuJoCo pixel environments. EGL contexts now share a ref-counted display handle so one thread-local renderer cannot terminate the process EGL display while another renderer still needs it during teardown. The offscreen renderer destructor is also no-throw: if the GL context is already unavailable during Python/interpreter shutdown, it frees CPU-side MuJoCo scene state and avoids aborting the process.

The regression coverage now exercises all native MuJoCo GL-backed families in one EGL subprocess: DMC, Gym MuJoCo, Robotics, MetaWorld, and MyoSuite. The test intentionally leaves env objects alive until interpreter shutdown, matching the failure mode where the rollout succeeds and the process aborts while exiting.

## Motivation and Context

close #401

The reported script successfully resets a `WalkerWalk-v1` pixel env and then aborts at process exit with `failed to make EGL context current`. I reproduced the same exit-134 crash on the dev GPU devbox, including when calling `pixels.close()`, which points at renderer/context teardown rather than user API misuse.

- [x] I have raised an issue to propose this change ([required](https://envpool.readthedocs.io/en/latest/pages/contributing.html) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [x] Share EGL display lifetime across native MuJoCo EGL contexts.
- [x] Make native offscreen renderer teardown safe during interpreter shutdown.
- [x] Add all-family EGL pixel-env teardown regression coverage.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the code using `make lint` (**required**)
- [ ] I have ensured `make bazel-test` pass. (**required**)

Validation run:

- devbox `dev-0`: reproduced issue #401 with exit status 134 before the fix.
- devbox `dev-0`: `make bazel-test BAZEL_TEST_TARGETS=//envpool/mujoco:mujoco_egl_teardown_test`
- devbox `dev-0`: `make bazel-test BAZEL_TEST_TARGETS=//envpool/mujoco:mujoco_pixel_observation_test`
- devbox `dev-0`: rebuilt and reinstalled the local wheel, then reran the original `envpool.make("WalkerWalk-v1", from_pixels=True, num_envs=2, frame_stack=3, ...)` script successfully with exit status 0.
- local: `ruff check envpool/mujoco/mujoco_egl_teardown_test.py envpool/mujoco/pixel_observation_test_utils.py envpool/mujoco/dmc/mujoco_dmc_pixel_observation_test.py`
- local: `git diff --check`
- local: `clang-format --style=file -i envpool/mujoco/offscreen_renderer.cc -n --Werror`
