### PR TITLE
[envpool] Support Gymnasium vector wrappers

### DIFF
--- a/docs/content/python_interface.rst
+++ b/docs/content/python_interface.rst
@@ -55,6 +55,11 @@ The observation space and action space of resulted environment describe a
 single environment's space, but each time the observation/action's first
 dimension is always equal to ``num_envs``
 (sync mode) or equal to ``batch_size`` (async mode).
+For Gymnasium compatibility, the Gymnasium wrapper also exposes
+``num_envs``, ``is_vector_env``, ``single_observation_space``, and
+``single_action_space`` for vector-aware wrappers such as Gymnasium's vector
+``NormalizeObservation``. EnvPool keeps ``observation_space`` and
+``action_space`` as the single-environment spaces for backward compatibility.
 
 ``envpool.make_gym``, ``envpool.make_dm``, and ``envpool.make_gymnasium`` are
 shortcuts for ``envpool.make(..., env_type="gym" | "dm" | "gymnasium")``,

--- a/envpool/__init__.py
+++ b/envpool/__init__.py
@@ -37,7 +37,7 @@ from envpool.registration import (
     register,
 )
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __all__ = [
     "register",
     "make",

--- a/envpool/classic_control/classic_control_test.py
+++ b/envpool/classic_control/classic_control_test.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Unit tests for classic control environments."""
 
-from typing import Any, no_type_check
+from typing import Any, cast, no_type_check
 
 import gymnasium as gym
 import numpy as np
@@ -81,6 +81,44 @@ class _ClassicControlEnvPoolTest(absltest.TestCase):
         env1 = make_gym("CartPole-v1")
         self.run_space_check(env0, env1)
         self.run_deterministic_check("CartPole-v1")
+
+    def test_cartpole_gymnasium_vector_wrapper(self) -> None:
+        num_envs = 4
+        env = make_gym("CartPole-v1", num_envs=num_envs)
+        self.assertEqual(env.num_envs, num_envs)
+        self.assertTrue(env.is_vector_env)
+        self.assertIs(env.single_observation_space, env.observation_space)
+        self.assertIs(env.single_action_space, env.action_space)
+        if hasattr(gym, "vector") and hasattr(gym.vector, "VectorEnv"):
+            self.assertIsInstance(env, gym.vector.VectorEnv)
+
+        vector_wrappers = getattr(gym.wrappers, "vector", None)
+        normalize_observation = getattr(
+            vector_wrappers, "NormalizeObservation", None
+        )
+        if normalize_observation is None:
+            normalize_observation = gym.wrappers.NormalizeObservation
+        wrapped = cast(Any, normalize_observation)(env)
+        try:
+            obs, _ = wrapped.reset()
+            if hasattr(wrapped, "num_envs"):
+                self.assertEqual(wrapped.num_envs, num_envs)
+            if hasattr(wrapped, "is_vector_env"):
+                self.assertTrue(wrapped.is_vector_env)
+            self.assertEqual(
+                obs.shape, (num_envs, *env.single_observation_space.shape)
+            )
+            obs, rew, term, trunc, _ = wrapped.step(
+                np.zeros(num_envs, dtype=np.int32)
+            )
+            self.assertEqual(
+                obs.shape, (num_envs, *env.single_observation_space.shape)
+            )
+            self.assertEqual(rew.shape, (num_envs,))
+            self.assertEqual(term.shape, (num_envs,))
+            self.assertEqual(trunc.shape, (num_envs,))
+        finally:
+            wrapped.close()
 
     def test_pendulum(self) -> None:
         env0 = gym.make("Pendulum-v1")

--- a/envpool/python/gymnasium_envpool.py
+++ b/envpool/python/gymnasium_envpool.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """EnvPool meta class for gymnasium.Env API."""
 
+import warnings
 from abc import ABCMeta
 from typing import Any, cast
 
@@ -24,11 +25,87 @@ from .data import gymnasium_structure
 from .envpool import EnvPoolMixin
 from .utils import check_key_duplication
 
+try:
+    from gymnasium.vector import VectorEnv as _GymnasiumVectorEnv
+except (AttributeError, ImportError):
+    _VECTOR_ENV_CLS: type | None = None
+else:
+    _VECTOR_ENV_CLS = _GymnasiumVectorEnv
+
+try:
+    from gymnasium.vector.vector_env import AutoresetMode as _AutoresetMode
+except (AttributeError, ImportError):
+    _AUTORESET_MODE = None
+else:
+    _AUTORESET_MODE = _AutoresetMode.NEXT_STEP
+
+
+def _gymnasium_base_classes() -> tuple[type, ...]:
+    if _VECTOR_ENV_CLS is None:
+        return (gymnasium.Env,)
+    if issubclass(_VECTOR_ENV_CLS, gymnasium.Env):
+        return (_VECTOR_ENV_CLS,)
+    return (_VECTOR_ENV_CLS, gymnasium.Env)
+
+
+def _env_ids_from_reset_options(
+    options: dict[str, Any] | None, num_envs: int
+) -> np.ndarray | None:
+    if options is None:
+        return None
+    allowed_options = {"reset_mask"}
+    unknown_options = set(options) - allowed_options
+    if unknown_options:
+        raise ValueError(
+            "Unsupported Gymnasium reset options for EnvPool: "
+            f"{sorted(unknown_options)}"
+        )
+    reset_mask = options.get("reset_mask")
+    if reset_mask is None:
+        return None
+    reset_mask = np.asarray(reset_mask, dtype=np.bool_)
+    if reset_mask.shape != (num_envs,):
+        raise ValueError(
+            f"reset_mask must have shape ({num_envs},), got {reset_mask.shape}"
+        )
+    if not np.any(reset_mask):
+        raise ValueError("reset_mask must select at least one environment.")
+    return np.flatnonzero(reset_mask).astype(np.int32)
+
 
 class GymnasiumEnvPoolMixin:
     """Special treatment for gymnasim API."""
 
-    metadata = {"render_modes": ["rgb_array", "human"]}
+    metadata = (
+        {
+            "render_modes": ["rgb_array", "human"],
+            "autoreset_mode": _AUTORESET_MODE,
+        }
+        if _AUTORESET_MODE is not None
+        else {"render_modes": ["rgb_array", "human"]}
+    )
+
+    @property
+    def num_envs(self: Any) -> int:
+        """Number of sub-environments in this vectorized EnvPool."""
+        return int(self.config["num_envs"])
+
+    @property
+    def is_vector_env(self: Any) -> bool:
+        """Compatibility flag used by older Gymnasium vector-aware wrappers."""
+        return True
+
+    @property
+    def single_observation_space(
+        self: Any,
+    ) -> gymnasium.Space | dict[str, Any]:
+        """Single sub-environment observation space."""
+        return self.observation_space
+
+    @property
+    def single_action_space(self: Any) -> gymnasium.Space | dict[str, Any]:
+        """Single sub-environment action space."""
+        return self.action_space
 
     @property
     def observation_space(self: Any) -> gymnasium.Space | dict[str, Any]:
@@ -49,6 +126,37 @@ class GymnasiumEnvPoolMixin:
         """Render mode configured at construction time."""
         return getattr(self, "_render_mode", None)
 
+    def reset(
+        self: Any,
+        env_id: np.ndarray | None = None,
+        *,
+        seed: int | list[int] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> Any:
+        """Reset with Gymnasium-compatible seed and options keywords."""
+        if seed is not None:
+            warnings.warn(
+                "EnvPool seeds are fixed when the environment is created. "
+                "reset(seed=...) is ignored; pass seed to envpool.make "
+                "instead.",
+                stacklevel=2,
+            )
+        option_env_id = _env_ids_from_reset_options(
+            options, self.config["num_envs"]
+        )
+        if env_id is not None and option_env_id is not None:
+            raise ValueError(
+                "Pass either env_id or options['reset_mask'], not both."
+            )
+        if option_env_id is not None:
+            env_id = option_env_id
+        return cast(Any, super()).reset(env_id)
+
+    def close(self: Any, **kwargs: Any) -> None:
+        """Accept Gymnasium VectorEnv close kwargs without changing EnvPool."""
+        del kwargs
+        return cast(Any, super()).close()
+
 
 class GymnasiumEnvPoolMeta(
     ABCMeta,
@@ -67,7 +175,7 @@ class GymnasiumEnvPoolMeta(
                 GymnasiumEnvPoolMixin,
                 EnvPoolMixin,
                 XlaMixin,
-                gymnasium.Env,
+                *_gymnasium_base_classes(),
             )
         except (ImportError, AttributeError):
 
@@ -77,7 +185,12 @@ class GymnasiumEnvPoolMeta(
                 )
 
             attrs["xla"] = _xla
-            parents = (base, GymnasiumEnvPoolMixin, EnvPoolMixin, gymnasium.Env)
+            parents = (
+                base,
+                GymnasiumEnvPoolMixin,
+                EnvPoolMixin,
+                *_gymnasium_base_classes(),
+            )
 
         state_keys = base._state_keys
         action_keys = base._action_keys

--- a/envpool/python/protocol.py
+++ b/envpool/python/protocol.py
@@ -349,12 +349,28 @@ class GymnasiumEnvPool(EnvPool, Protocol):
     """gymnasium-compatible EnvPool interface."""
 
     @property
+    def num_envs(self) -> int:
+        """Number of sub-environments."""
+
+    @property
+    def is_vector_env(self) -> bool:
+        """Whether the EnvPool should be treated as vectorized."""
+
+    @property
     def observation_space(self) -> Any:
         """Gymnasium observation space."""
 
     @property
+    def single_observation_space(self) -> Any:
+        """Gymnasium single sub-environment observation space."""
+
+    @property
     def action_space(self) -> Any:
         """Gymnasium action space."""
+
+    @property
+    def single_action_space(self) -> Any:
+        """Gymnasium single sub-environment action space."""
 
     @overload
     def recv(
@@ -394,5 +410,8 @@ class GymnasiumEnvPool(EnvPool, Protocol):
     def reset(
         self,
         env_id: np.ndarray | None = None,
+        *,
+        seed: int | list[int] | None = None,
+        options: dict[str, Any] | None = None,
     ) -> GymnasiumResetReturn:
         """Reset the gymnasium-compatible envpool."""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = envpool
-version = 1.2.1
+version = 1.2.2
 author = "EnvPool Contributors"
 author_email = "sail@sea.com"
 description = "C++-based high-performance parallel environment execution engine (vectorized env) for general RL environments."


### PR DESCRIPTION
## Description

Adds Gymnasium vector compatibility metadata to EnvPool's Gymnasium wrapper so vector-aware wrappers, including `gymnasium.wrappers.vector.NormalizeObservation`, can recognize EnvPool as a vector environment.

The change keeps EnvPool's existing backward-compatible space contract: `observation_space` and `action_space` still describe one sub-environment, and the Gymnasium wrapper now also exposes `num_envs`, `is_vector_env`, `single_observation_space`, and `single_action_space`.

This also bumps EnvPool from `1.2.1` to `1.2.2`.

## Motivation and Context

Fixes #258.

The original blocker was Gym/Gymnasium vector API incompatibility. Gymnasium now supports the vector wrapper shape EnvPool needs, so EnvPool can provide the expected vector attributes without changing the dm_env wrapper or the underlying runtime.

- [x] I have raised an issue to propose this change ([required](https://envpool.readthedocs.io/en/latest/pages/contributing.html) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [x] Add Gymnasium vector metadata and `VectorEnv` compatibility on the Gymnasium wrapper only
- [x] Add a CartPole regression test covering Gymnasium vector `NormalizeObservation`
- [x] Bump package version to `1.2.2`

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [x] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [x] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [x] I have checked the code using `ruff check envpool/python/gymnasium_envpool.py envpool/python/protocol.py envpool/classic_control/classic_control_test.py envpool/__init__.py`
- [ ] I have ensured `make bazel-test` pass. (**required**)

Validation run:
- `ruff check envpool/python/gymnasium_envpool.py envpool/python/protocol.py envpool/classic_control/classic_control_test.py envpool/__init__.py`
- `mypy envpool/python/gymnasium_envpool.py envpool/python/protocol.py envpool/classic_control/classic_control_test.py envpool/__init__.py`
- `bazel test --test_output=errors --test_filter=_ClassicControlEnvPoolTest.test_cartpole_gymnasium_vector_wrapper --action_env=PATH=/Users/jiayi/.virtualenvs/openai/bin:/bin:/usr/bin:/usr/local/bin //envpool/classic_control:classic_control_test`
- `bazel test --test_output=errors --test_filter=_DummyEnvPoolTest.test_config //envpool/dummy:dummy_py_envpool_test`
