### PR TITLE
[mujoco] Avoid EGL pbuffer warnings

### DIFF
--- a/envpool/mujoco/offscreen_renderer.cc
+++ b/envpool/mujoco/offscreen_renderer.cc
@@ -25,6 +25,7 @@
 #include <memory>
 #include <mutex>
 #include <stdexcept>
+#include <string_view>
 #include <vector>
 
 #if defined(__APPLE__) && __has_include(<OpenGL/OpenGL.h>)
@@ -382,15 +383,20 @@ class EglContext final : public GlContext {
       display_.reset();
       throw std::runtime_error("failed to bind EGL OpenGL API");
     }
-    surface_ = eglCreatePbufferSurface(display, config, pbuffer_attribs.data());
-    if (surface_ == EGL_NO_SURFACE) {
-      display_.reset();
-      throw std::runtime_error("failed to create EGL pbuffer surface");
+    if (!HasExtension(display, "EGL_KHR_surfaceless_context")) {
+      surface_ =
+          eglCreatePbufferSurface(display, config, pbuffer_attribs.data());
+      if (surface_ == EGL_NO_SURFACE) {
+        display_.reset();
+        throw std::runtime_error("failed to create EGL pbuffer surface");
+      }
     }
     context_ = eglCreateContext(display, config, EGL_NO_CONTEXT, nullptr);
     if (context_ == EGL_NO_CONTEXT) {
-      eglDestroySurface(display, surface_);
-      surface_ = EGL_NO_SURFACE;
+      if (surface_ != EGL_NO_SURFACE) {
+        eglDestroySurface(display, surface_);
+        surface_ = EGL_NO_SURFACE;
+      }
       display_.reset();
       throw std::runtime_error("failed to create EGL context");
     }
@@ -442,6 +448,26 @@ class EglContext final : public GlContext {
    private:
     EGLDisplay display_{EGL_NO_DISPLAY};
   };
+
+  static bool HasExtension(EGLDisplay display, const char* extension) {
+    const char* extensions = eglQueryString(display, EGL_EXTENSIONS);
+    if (extensions == nullptr) {
+      return false;
+    }
+    const std::string_view list(extensions);
+    const std::string_view needle(extension);
+    std::size_t pos = 0;
+    while ((pos = list.find(needle, pos)) != std::string_view::npos) {
+      const bool begins_token = pos == 0 || list[pos - 1] == ' ';
+      const std::size_t end = pos + needle.size();
+      const bool ends_token = end == list.size() || list[end] == ' ';
+      if (begins_token && ends_token) {
+        return true;
+      }
+      pos = end;
+    }
+    return false;
+  }
 
   static EGLDisplay TryInitializeDisplay(EGLDisplay display) {
     if (display == EGL_NO_DISPLAY) {

--- a/envpool/mujoco/pixel_observation_test_utils.py
+++ b/envpool/mujoco/pixel_observation_test_utils.py
@@ -264,7 +264,7 @@ def assert_egl_pixel_env_teardown_exits_cleanly(
     test: absltest.TestCase,
     cases: Sequence[EglTeardownCase],
 ) -> None:
-    """Checks EGL pixel envs from multiple families can exit cleanly.
+    """Checks EGL pixel envs from multiple families exit without GL noise.
 
     The subprocess intentionally keeps envs alive until interpreter shutdown:
     issue #401 happens in teardown, after the rollout itself has succeeded.
@@ -336,5 +336,10 @@ for label, registration_module, task_id in {tuple(cases)!r}:
     test.assertEqual(
         result.returncode,
         0,
+        msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+    )
+    test.assertNotIn(
+        "OpenGL error 0x502 in or before mjr_makeContext",
+        result.stderr,
         msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
     )


### PR DESCRIPTION
## Description

Use an EGL surfaceless context for MuJoCo offscreen rendering when `EGL_KHR_surfaceless_context` is available, matching the context shape used by upstream `mujoco.egl.GLContext`. Keep the existing 1x1 pbuffer fallback for drivers that do not advertise surfaceless contexts.

This prevents MuJoCo from treating the EGL pbuffer as an available default window framebuffer, which can leave `GL_INVALID_OPERATION` queued and produce:

`OpenGL error 0x502 in or before mjr_makeContext`

The existing EGL teardown subprocess test now also fails if that warning appears on stderr.

## Motivation and Context

Follow-up to #401 and the latest issue comment: the crash was fixed, but source builds could still run successfully while printing the MuJoCo OpenGL warning above. This change keeps the renderer headless from MuJoCo's point of view so native pixel observation envs do not emit the warning.

- [x] I have raised an issue to propose this change ([required](https://envpool.readthedocs.io/en/latest/pages/contributing.html) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [x] Prefer EGL surfaceless contexts for native MuJoCo offscreen rendering.
- [x] Preserve pbuffer fallback when surfaceless contexts are unavailable.
- [x] Add regression coverage for the MuJoCo `mjr_makeContext` OpenGL warning.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the code using `make lint` (**required**)
- [ ] I have ensured `make bazel-test` pass. (**required**)

Validation run:

- `clang-format --style=file -i envpool/mujoco/offscreen_renderer.cc -n --Werror`
- `ruff check envpool/mujoco/pixel_observation_test_utils.py`
- `ruff format --check envpool/mujoco/pixel_observation_test_utils.py`
- `git diff --check -- envpool/mujoco/offscreen_renderer.cc envpool/mujoco/pixel_observation_test_utils.py`
- `bazel test --test_output=errors //envpool/mujoco:mujoco_egl_teardown_test`

Devbox Linux validation was attempted, but the Brix API endpoint is currently failing DNS resolution from this client. The PR CI should run the Linux/EGL path directly.
