### PR TITLE
[mujoco] Fix concurrent EGL context reuse

### DIFF
--- a/envpool/mujoco/mujoco_egl_teardown_test.py
+++ b/envpool/mujoco/mujoco_egl_teardown_test.py
@@ -16,6 +16,7 @@
 from absl.testing import absltest
 
 from envpool.mujoco.pixel_observation_test_utils import (
+    assert_egl_async_pixel_envs_do_not_share_context_concurrently,
     assert_egl_pixel_env_teardown_exits_cleanly,
 )
 
@@ -42,6 +43,12 @@ class MujocoEglTeardownTest(absltest.TestCase):
     def test_pixel_env_teardown_exits_cleanly_for_all_gl_families(self) -> None:
         """All native MuJoCo pixel families should exit cleanly under EGL."""
         assert_egl_pixel_env_teardown_exits_cleanly(self, _EGL_TEARDOWN_CASES)
+
+    def test_async_pixel_envs_do_not_share_egl_context_concurrently(
+        self,
+    ) -> None:
+        """Async pixel envs should not reuse one EGL context concurrently."""
+        assert_egl_async_pixel_envs_do_not_share_context_concurrently(self)
 
 
 if __name__ == "__main__":

--- a/envpool/mujoco/offscreen_renderer.cc
+++ b/envpool/mujoco/offscreen_renderer.cc
@@ -437,10 +437,12 @@ class EglContext final : public GlContext {
     explicit DisplayHandle(EGLDisplay display) : display_(display) {}
 
     ~DisplayHandle() {
-      if (display_ != EGL_NO_DISPLAY) {
-        eglTerminate(display_);
-        eglReleaseThread();
-      }
+      // EGLDisplay handles are process-wide. Python MuJoCo/Gymnasium renderers
+      // cache the same display in module globals, so terminating it when the
+      // last EnvPool renderer closes can invalidate later upstream renders in
+      // the same process. Contexts and surfaces remain renderer-owned and are
+      // destroyed normally; keep the display alive until process teardown.
+      eglReleaseThread();
     }
 
     EGLDisplay Get() const { return display_; }
@@ -554,10 +556,9 @@ class EglContext final : public GlContext {
 
   static std::shared_ptr<DisplayHandle> AcquireDisplay() {
     static std::mutex mutex;
-    static std::weak_ptr<DisplayHandle> weak_display;
+    static std::shared_ptr<DisplayHandle> display;
 
     std::lock_guard<std::mutex> lock(mutex);
-    std::shared_ptr<DisplayHandle> display = weak_display.lock();
     if (display != nullptr) {
       return display;
     }
@@ -566,7 +567,6 @@ class EglContext final : public GlContext {
       return nullptr;
     }
     display = std::make_shared<DisplayHandle>(raw_display);
-    weak_display = display;
     return display;
   }
 
@@ -608,9 +608,12 @@ std::shared_ptr<GlContext> CreateGlContext(bool share_cgl_context,
 #elif defined(ENVPOOL_HAS_EGL)
   (void)share_cgl_context;
   (void)prefer_offline_cgl_context;
-  thread_local std::shared_ptr<GlContext> context =
-      std::make_shared<EglContext>();
-  return context;
+  // EnvPool worker threads can process a different environment on a later
+  // reset/step. If multiple renderers created on one worker share a thread
+  // local EGLContext, those renderers can later try to make the same context
+  // current concurrently on different workers. Keep the EGLDisplay shared, but
+  // give each renderer its own EGLContext.
+  return std::make_shared<EglContext>();
 #else
   (void)share_cgl_context;
   (void)prefer_offline_cgl_context;

--- a/envpool/mujoco/pixel_observation_test_utils.py
+++ b/envpool/mujoco/pixel_observation_test_utils.py
@@ -38,6 +38,7 @@ EGL_TEARDOWN_RENDER_WIDTH = 84
 EGL_TEARDOWN_RENDER_HEIGHT = 84
 EGL_TEARDOWN_FRAME_STACK = 3
 EGL_TEARDOWN_SUBPROCESS_TIMEOUT_SECONDS = 180
+EGL_ASYNC_CONTEXT_STEPS = 64
 EglTeardownCase = tuple[str, str, str]
 
 
@@ -340,6 +341,97 @@ for label, registration_module, task_id in {tuple(cases)!r}:
     )
     test.assertNotIn(
         "OpenGL error 0x502 in or before mjr_makeContext",
+        result.stderr,
+        msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+    )
+
+
+def assert_egl_async_pixel_envs_do_not_share_context_concurrently(
+    test: absltest.TestCase,
+) -> None:
+    """Checks async pixel rendering does not reuse one EGL context in workers."""
+    if platform.system() != "Linux":
+        test.skipTest("EGL context regression is Linux-specific.")
+    env = dict(os.environ)
+    env["MUJOCO_GL"] = "egl"
+    env.setdefault("EGL_PLATFORM", "surfaceless")
+
+    package_parent = os.path.dirname(
+        os.path.dirname(os.path.dirname(envpool_glfw_context.__file__))
+    )
+    python_paths = [package_parent] + [
+        path for path in sys.path if path and path != package_parent
+    ]
+    python_path = os.pathsep.join(python_paths)
+    if env.get("PYTHONPATH"):
+        python_path = f"{python_path}{os.pathsep}{env['PYTHONPATH']}"
+    env["PYTHONPATH"] = python_path
+
+    code = f"""
+import importlib
+import sys
+
+import numpy as np
+
+sys.path.insert(0, {package_parent!r})
+sys.modules.pop("envpool", None)
+importlib.import_module("envpool.mujoco.dmc.registration")
+from envpool.registration import make
+
+pixels = make(
+    "WalkerWalk-v1",
+    env_type="gymnasium",
+    num_envs=4,
+    batch_size=2,
+    num_threads=2,
+    from_pixels=True,
+    render_width={RENDER_WIDTH},
+    render_height={RENDER_HEIGHT},
+)
+pixels.async_reset()
+for _ in range(2):
+    obs, reward, term, trunc, info = pixels.recv()
+    assert obs.shape == (2, 3, {RENDER_HEIGHT}, {RENDER_WIDTH}), obs.shape
+
+action = np.zeros((2,) + pixels.action_space.shape, dtype=np.float64)
+pairs = [
+    np.asarray([0, 2], dtype=np.int32),
+    np.asarray([1, 3], dtype=np.int32),
+    np.asarray([0, 3], dtype=np.int32),
+    np.asarray([1, 2], dtype=np.int32),
+]
+for i in range({EGL_ASYNC_CONTEXT_STEPS}):
+    pixels.send(action, pairs[i % len(pairs)])
+    obs, reward, term, trunc, info = pixels.recv()
+    assert obs.shape == (2, 3, {RENDER_HEIGHT}, {RENDER_WIDTH}), obs.shape
+
+pixels.close()
+print("successful async egl context stress")
+"""
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=EGL_TEARDOWN_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = _subprocess_output_to_text(exc.stdout)
+        stderr = _subprocess_output_to_text(exc.stderr)
+        test.fail(
+            "EGL async context subprocess timed out after "
+            f"{EGL_TEARDOWN_SUBPROCESS_TIMEOUT_SECONDS} seconds.\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}"
+        )
+    test.assertEqual(
+        result.returncode,
+        0,
+        msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+    )
+    test.assertNotIn(
+        "failed to make EGL context current",
         result.stderr,
         msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
     )


### PR DESCRIPTION
## Description

Fix MuJoCo EGL offscreen rendering so async pixel environments do not share one thread-local EGL context across multiple renderers. EGL still reuses the process display handle, but each `OffscreenRenderer` now owns its own `EGLContext`, preventing later worker-thread scheduling from making the same context current concurrently.

This also adds Linux/EGL subprocess coverage that stresses async DMC pixel rendering across two workers and validates the process does not abort with `failed to make EGL context current`.

## Motivation and Context

Fixes #405.

Large pixel-based DMC pools can create multiple renderers on the same worker during reset, then later step those environments on different workers. The previous Linux path returned a `thread_local` EGL context, so those renderers could later race on the same context and abort inside `eglMakeCurrent`.

- [x] I have raised an issue to propose this change ([required](https://envpool.readthedocs.io/en/latest/pages/contributing.html) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [x] Reproduce the EGL context-current failure on dev with an async DMC pixel stress case.
- [x] Stop sharing one EGL context between multiple offscreen renderers.
- [x] Add Linux/EGL regression coverage for async pixel rendering.

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the code using `make lint` (**required**)
- [ ] I have ensured `make bazel-test` pass. (**required**)

Validation run:

- `bazel test --test_output=all //envpool/mujoco:mujoco_egl_teardown_test` on dev-0
- `bazel test --test_output=errors //envpool/mujoco:mujoco_dmc_pixel_observation_test` on dev-0
- Manual async EGL stress script on dev-0: reproduced `failed to make EGL context current` before the fix and passed 1000 async steps after the fix
- `git diff --check`
- `python -m py_compile envpool/mujoco/pixel_observation_test_utils.py envpool/mujoco/mujoco_egl_teardown_test.py`
