### PR TITLE
Fix Bazel cache reuse on CI reruns

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Run clang-tidy
         run: |
           make BAZELOPT="--repository_cache=$HOME/.cache/envpool-bazel-repo --disk_cache=$HOME/.cache/envpool-bazel-disk" clang-tidy
+      - name: Shut down Bazel
+        if: ${{ always() && !cancelled() }}
+        continue-on-error: true
+        run: bazelisk shutdown
       - name: Save Bazel caches
         id: save-bazel-caches
         if: ${{ always() && !cancelled() }}
@@ -69,9 +73,9 @@ jobs:
             ~/.cache/bazelisk
             ~/.cache/envpool-bazel-repo
             ~/.cache/envpool-bazel-disk
-          key: bazel-clang-tidy-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion') }}-${{ env.CACHE_BRANCH }}-${{ github.run_id }}
+          key: bazel-clang-tidy-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion') }}-${{ env.CACHE_BRANCH }}-${{ github.run_id }}-attempt${{ github.run_attempt }}
       - name: Prune older Bazel caches
-        if: ${{ always() && !cancelled() && (steps.save-bazel-caches.outcome == 'success' || steps.save-bazel-caches.outcome == 'skipped') }}
+        if: ${{ success() && (steps.save-bazel-caches.outcome == 'success' || steps.save-bazel-caches.outcome == 'skipped') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,10 @@ jobs:
             --badge-file coverage/coverage-badge.svg \
             --genhtml-lcov-file coverage/lcov.genhtml.info \
             --repo-root "$GITHUB_WORKSPACE"
+      - name: Shut down Bazel
+        if: ${{ always() && !cancelled() }}
+        continue-on-error: true
+        run: bazelisk shutdown
       - name: Publish coverage summary
         run: cat coverage/summary.md >> "$GITHUB_STEP_SUMMARY"
       - name: Build coverage site
@@ -111,9 +115,9 @@ jobs:
             ~/.cache/bazelisk
             ~/.cache/envpool-bazel-repo
             ~/.cache/envpool-bazel-disk
-          key: bazel-test-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion') }}-${{ env.CACHE_BRANCH }}-${{ github.run_id }}
+          key: bazel-test-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion') }}-${{ env.CACHE_BRANCH }}-${{ github.run_id }}-attempt${{ github.run_attempt }}
       - name: Prune older Bazel caches
-        if: ${{ always() && !cancelled() && (steps.save-bazel-caches.outcome == 'success' || steps.save-bazel-caches.outcome == 'skipped') }}
+        if: ${{ success() && (steps.save-bazel-caches.outcome == 'success' || steps.save-bazel-caches.outcome == 'skipped') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -182,6 +186,10 @@ jobs:
         run: |
           make BAZELOPT="--repository_cache=$HOME/.cache/envpool-bazel-repo --disk_cache=$HOME/.cache/envpool-bazel-disk $BAZEL_CI_RESOURCE_OPTS" \
             BAZEL_TEST_TARGETS="//..." bazel-test
+      - name: Shut down Bazel
+        if: ${{ always() && !cancelled() }}
+        continue-on-error: true
+        run: bazelisk shutdown
       - name: Save Bazel caches
         id: save-bazel-caches
         if: ${{ always() && !cancelled() }}
@@ -191,9 +199,9 @@ jobs:
             ~/.cache/bazelisk
             ~/.cache/envpool-bazel-repo
             ~/.cache/envpool-bazel-disk
-          key: bazel-test-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion') }}-${{ env.CACHE_BRANCH }}-${{ github.run_id }}
+          key: bazel-test-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion') }}-${{ env.CACHE_BRANCH }}-${{ github.run_id }}-attempt${{ github.run_attempt }}
       - name: Prune older Bazel caches
-        if: ${{ always() && !cancelled() && (steps.save-bazel-caches.outcome == 'success' || steps.save-bazel-caches.outcome == 'skipped') }}
+        if: ${{ success() && (steps.save-bazel-caches.outcome == 'success' || steps.save-bazel-caches.outcome == 'skipped') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -261,6 +269,10 @@ jobs:
       - name: Test
         run: |
           make BAZELOPT="--repository_cache=$HOME/.cache/envpool-bazel-repo --disk_cache=$HOME/.cache/envpool-bazel-disk $BAZEL_CI_RESOURCE_OPTS" bazel-test
+      - name: Shut down Bazel
+        if: ${{ always() && !cancelled() }}
+        continue-on-error: true
+        run: bazelisk shutdown
       - name: Save Bazel caches
         id: save-bazel-caches
         if: ${{ always() && !cancelled() }}
@@ -270,9 +282,9 @@ jobs:
             ~/.cache/bazelisk
             ~/.cache/envpool-bazel-repo
             ~/.cache/envpool-bazel-disk
-          key: bazel-test-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion') }}-${{ env.CACHE_BRANCH }}-${{ github.run_id }}
+          key: bazel-test-v3-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion') }}-${{ env.CACHE_BRANCH }}-${{ github.run_id }}-attempt${{ github.run_attempt }}
       - name: Prune older Bazel caches
-        if: ${{ always() && !cancelled() && (steps.save-bazel-caches.outcome == 'success' || steps.save-bazel-caches.outcome == 'skipped') }}
+        if: ${{ success() && (steps.save-bazel-caches.outcome == 'success' || steps.save-bazel-caches.outcome == 'skipped') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
@@ -291,8 +303,10 @@ jobs:
       BAZEL_SH: C:/Program Files/Git/usr/bin/bash.exe
       CACHE_BRANCH: ${{ github.head_ref || github.ref_name }}
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-      BAZEL_CI_RESOURCE_OPTS: --jobs=HOST_CPUS-1 --local_cpu_resources=HOST_CPUS-1 --local_ram_resources=HOST_RAM*.5 --experimental_disk_cache_gc_max_size=2G --experimental_disk_cache_gc_idle_delay=0s
-      BAZEL_CACHE_PREFIX: bazel-test-v5-windows-capped
+      # MSVC ignores the POSIX -g0/-O3 flags from --config=test. Use opt mode
+      # and a larger capped disk cache so Windows reruns are not cold builds.
+      BAZEL_CI_RESOURCE_OPTS: --compilation_mode=opt --jobs=HOST_CPUS-1 --local_cpu_resources=HOST_CPUS-1 --local_ram_resources=HOST_RAM*.5 --experimental_disk_cache_gc_max_size=4G --experimental_disk_cache_gc_idle_delay=0s
+      BAZEL_CACHE_PREFIX: bazel-test-v6-windows-opt-cache4g
       MESA_GL_VERSION_OVERRIDE: 4.5COMPAT
       MSYS2_ARG_CONV_EXCL: "*"
       MSYS_NO_PATHCONV: "1"
@@ -384,6 +398,11 @@ jobs:
           repo_cache=$(cygpath -am "$HOME/.cache/envpool-bazel-repo")
           disk_cache=$(cygpath -am "$HOME/.cache/envpool-bazel-disk")
           make BAZELOPT="--repository_cache=$repo_cache --disk_cache=$disk_cache $BAZEL_CI_RESOURCE_OPTS" bazel-test
+      - name: Shut down Bazel
+        if: ${{ always() && !cancelled() }}
+        continue-on-error: true
+        shell: bash
+        run: bazelisk shutdown
       - name: Save Bazel caches
         id: save-bazel-caches
         if: ${{ always() && !cancelled() }}
@@ -393,9 +412,9 @@ jobs:
             ~/.cache/bazelisk
             ~/.cache/envpool-bazel-repo
             ~/.cache/envpool-bazel-disk
-          key: ${{ env.BAZEL_CACHE_PREFIX }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion') }}-${{ env.CACHE_BRANCH }}-${{ github.run_id }}
+          key: ${{ env.BAZEL_CACHE_PREFIX }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bazelversion') }}-${{ env.CACHE_BRANCH }}-${{ github.run_id }}-attempt${{ github.run_attempt }}
       - name: Prune older Bazel caches
-        if: ${{ always() && !cancelled() && (steps.save-bazel-caches.outcome == 'success' || steps.save-bazel-caches.outcome == 'skipped') }}
+        if: ${{ success() && (steps.save-bazel-caches.outcome == 'success' || steps.save-bazel-caches.outcome == 'skipped') }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/envpool/jumanji/BUILD
+++ b/envpool/jumanji/BUILD
@@ -289,7 +289,7 @@ py_test(
 
 py_test(
     name = "jumanji_maze_test",
-    size = "small",
+    size = "medium",
     srcs = ["jumanji_maze_test.py"],
     imports = ["../.."],
     deps = [

--- a/envpool/vizdoom/BUILD
+++ b/envpool/vizdoom/BUILD
@@ -152,7 +152,7 @@ py_test(
 
 py_test(
     name = "vizdoom_test",
-    size = "small",
+    size = "medium",
     srcs = ["vizdoom_test.py"],
     imports = ["../.."],
     tags = ["exclusive"],
@@ -166,7 +166,7 @@ py_test(
 
 py_test(
     name = "vizdoom_pretrain_test",
-    size = "medium",
+    size = "large",
     srcs = ["vizdoom_pretrain_test.py"],
     imports = ["../.."],
     tags = ["exclusive"],

--- a/scripts/BUILD
+++ b/scripts/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
 load("//envpool:requirements.bzl", "requirement")
 load("//third_party/jumanji:oracle_requirements.bzl", "jumanji_oracle_requirement")
 
@@ -40,4 +40,13 @@ py_binary(
         jumanji_oracle_requirement("pillow"),
         jumanji_oracle_requirement("requests"),
     ],
+)
+
+py_test(
+    name = "prune_actions_caches_test",
+    srcs = [
+        "prune_actions_caches.py",
+        "prune_actions_caches_test.py",
+    ],
+    main = "prune_actions_caches_test.py",
 )

--- a/scripts/prune_actions_caches.py
+++ b/scripts/prune_actions_caches.py
@@ -133,8 +133,21 @@ def _branch_name_from_cache_key(key: str, prefix: str) -> str | None:
     if not key.startswith(prefix):
         return None
     suffix = key[len(prefix) :]
-    branch, separator, run_id = suffix.rpartition("-")
-    if not separator or not branch or not run_id.isdigit():
+
+    def branch_from_run_suffix(value: str) -> str | None:
+        branch, separator, run_id = value.rpartition("-")
+        if not separator or not branch or not run_id.isdigit():
+            return None
+        return branch
+
+    branch_and_run, attempt_separator, attempt = suffix.rpartition("-attempt")
+    if attempt_separator and attempt.isdigit():
+        branch = branch_from_run_suffix(branch_and_run)
+        if branch is not None:
+            return branch
+
+    branch = branch_from_run_suffix(suffix)
+    if branch is None:
         return None
     return branch
 
@@ -184,7 +197,8 @@ def _stale_caches_by_branch(
     if ungrouped:
         print(
             f"Skipping {len(ungrouped)} caches whose keys do not match "
-            f"'<prefix><branch>-<run_id>' for prefix {prefix}",
+            f"'<prefix><branch>-<run_id>[-attempt<attempt>]' "
+            f"for prefix {prefix}",
             file=sys.stderr,
         )
     return sorted(stale_caches.values(), key=_sort_key, reverse=True)

--- a/scripts/prune_actions_caches_test.py
+++ b/scripts/prune_actions_caches_test.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+"""Tests for GitHub Actions cache pruning helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+def load_prune_actions_caches():
+    """Load the script module from the Bazel runfiles directory."""
+    module_path = Path(__file__).with_name("prune_actions_caches.py")
+    spec = importlib.util.spec_from_file_location(
+        "prune_actions_caches", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+prune_actions_caches = load_prune_actions_caches()
+
+
+class BranchNameFromCacheKeyTest(unittest.TestCase):
+    """Verify branch grouping for cache keys."""
+
+    def setUp(self) -> None:
+        """Set a stable cache key prefix."""
+        self.prefix = "bazel-test-v5-windows-capped-Windows-X64-hash-"
+
+    def branch_name(self, suffix: str) -> str | None:
+        """Parse a branch name from a cache key suffix."""
+        return prune_actions_caches._branch_name_from_cache_key(
+            f"{self.prefix}{suffix}", self.prefix
+        )
+
+    def test_legacy_run_id_suffix(self) -> None:
+        """Legacy keys use a numeric run id suffix."""
+        self.assertEqual(self.branch_name("main-25654277602"), "main")
+        self.assertEqual(
+            self.branch_name("jiayi/windows-cache-25654277602"),
+            "jiayi/windows-cache",
+        )
+        self.assertEqual(self.branch_name("release-1-25654277602"), "release-1")
+
+    def test_run_attempt_suffix(self) -> None:
+        """Rerun-aware keys include a numeric run attempt suffix."""
+        self.assertEqual(
+            self.branch_name("main-25654277602-attempt2"),
+            "main",
+        )
+        self.assertEqual(
+            self.branch_name("jiayi/windows-cache-25654277602-attempt2"),
+            "jiayi/windows-cache",
+        )
+        self.assertEqual(
+            self.branch_name("feature-attempt2-25654277602-attempt3"),
+            "feature-attempt2",
+        )
+
+    def test_malformed_keys(self) -> None:
+        """Malformed keys are ignored instead of grouped under a branch."""
+        self.assertIsNone(
+            prune_actions_caches._branch_name_from_cache_key(
+                "other-prefix-main-25654277602", self.prefix
+            )
+        )
+        self.assertIsNone(self.branch_name("main"))
+        self.assertIsNone(self.branch_name("main-run"))
+        self.assertIsNone(self.branch_name("main-25654277602-attempt"))
+        self.assertIsNone(self.branch_name("main-25654277602-attemptx"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix Windows CI warm-cache behavior: MSVC was ignoring the POSIX -g0/-O3 flags, so Windows kept producing large fastbuild outputs and the 2G disk cache retained almost nothing useful
- run Windows Bazel tests in opt mode, bump the capped Windows disk cache from 2G to 4G, and bump the Windows cache prefix
- add github.run_attempt to Bazel cache save keys so rerun attempts can save a fresh cache instead of colliding with the previous attempt
- shut down Bazel before saving caches and prune old caches only after successful jobs
- teach the pruning script to group both legacy branch-run_id keys and branch-run_id-attemptN keys
- raise the Bazel timeout size for Windows-observed slow tests that timed out while the cache was cold

## Evidence
- Windows attempt 1 restored cache but ended with 124 disk cache hits and 9541 local actions
- Windows attempt 2 restored the previous attempt's cache but still ended with only 132 disk cache hits and 9534 local actions
- macOS on the same main run restored cache and ended with 8383 disk cache hits and 329 local actions

## Test plan
- python3 scripts/prune_actions_caches_test.py
- ruff check scripts/prune_actions_caches.py scripts/prune_actions_caches_test.py
- ruff format --check scripts/prune_actions_caches.py scripts/prune_actions_caches_test.py
- bazel test --test_output=errors //scripts:prune_actions_caches_test