### PR TITLE
[release] Bump EnvPool assets to 0.3.0

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -52,6 +52,12 @@ filegroup(
     srcs = [".clang-tidy"],
 )
 
+filegroup(
+    name = "setup_cfg",
+    srcs = ["setup.cfg"],
+    visibility = ["//visibility:public"],
+)
+
 py_binary(
     name = "setup",
     srcs = _SETUP_SRCS,

--- a/envpool/BUILD
+++ b/envpool/BUILD
@@ -81,6 +81,7 @@ py_test(
     name = "make_test",
     timeout = "long",
     srcs = ["make_test.py"],
+    data = ["//:setup_cfg"],
     imports = [".."],
     deps = [
         ":envpool",

--- a/envpool/__init__.py
+++ b/envpool/__init__.py
@@ -37,7 +37,7 @@ from envpool.registration import (
     register,
 )
 
-__version__ = "1.2.4"
+__version__ = "1.2.5"
 __all__ = [
     "register",
     "make",

--- a/envpool/atari/registration.py
+++ b/envpool/atari/registration.py
@@ -15,9 +15,10 @@
 
 import os
 
-from envpool.registration import base_path, register
+from envpool.registration import asset_base_path, register
 
-atari_rom_path = os.path.join(base_path, "atari", "roms")
+_ATARI_BASE_PATH = asset_base_path("envpool_assets", "atari/roms")
+atari_rom_path = os.path.join(_ATARI_BASE_PATH, "atari", "roms")
 atari_game_list = sorted([
     i.replace(".bin", "") for i in os.listdir(atari_rom_path)
 ])
@@ -32,4 +33,5 @@ for game in atari_game_list:
         gymnasium_cls="AtariGymnasiumEnvPool",
         task=game,
         max_episode_steps=27000,
+        base_path=_ATARI_BASE_PATH,
     )

--- a/envpool/gfootball/registration.py
+++ b/envpool/gfootball/registration.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 """Google Research Football env registration."""
 
-from envpool.registration import register
+from envpool.registration import asset_base_path, register
+
+_GFOOTBALL_BASE_PATH = asset_base_path("envpool_assets", "gfootball/assets")
 
 _SCENARIOS = (
     ("11_vs_11_competition", 3000),
@@ -45,4 +47,5 @@ for env_name, max_episode_steps in _SCENARIOS:
         spec_cls="GfootballEnvSpec",
         dm_cls="GfootballDMEnvPool",
         gymnasium_cls="GfootballGymnasiumEnvPool",
+        base_path=_GFOOTBALL_BASE_PATH,
     )

--- a/envpool/make_test.py
+++ b/envpool/make_test.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Test for envpool.make."""
 
+import configparser
 import gc
 import os
 import pprint
@@ -22,6 +23,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Callable, get_type_hints
+from unittest import mock
 
 import dm_env
 import gymnasium
@@ -60,6 +62,32 @@ _VIZDOOM_RENDER_KWARGS: dict[str, object] = {
     "img_height": 240,
 }
 
+_FAMILY_SMOKE_TASKS: dict[str, tuple[str, ...]] = {
+    "envpool.atari": ("Defender-v5",),
+    "envpool.box2d": ("LunarLander-v3",),
+    "envpool.classic_control": ("CartPole-v1",),
+    "envpool.gfootball": ("gfootball/academy_empty_goal_close-v1",),
+    "envpool.highway": ("HighwayFast-v0",),
+    "envpool.jumanji": ("Game2048-v1",),
+    "envpool.minigrid": ("MiniGrid-DoorKey-8x8-v0",),
+    "envpool.mujoco.dmc": ("WalkerWalk-v1",),
+    "envpool.mujoco.gym": ("Ant-v5",),
+    "envpool.mujoco.metaworld": ("MetaWorld/Reach-v3",),
+    "envpool.mujoco.playground": (
+        "Go1JoystickFlatTerrain-v1",
+        "G1JoystickFlatTerrain-v1",
+    ),
+    "envpool.mujoco.robotics": ("FetchReach-v4",),
+    "envpool.pgx": ("TicTacToe-v1",),
+    "envpool.procgen": ("CoinrunEasy-v0",),
+    "envpool.toy_text": ("Catch-v0",),
+    "envpool.vizdoom": ("MyWayHome-v1",),
+}
+
+_DYNAMIC_FAMILY_SMOKE_PREFIXES: dict[str, str] = {
+    "envpool.mujoco.myosuite": "MyoSuite/",
+}
+
 
 @contextmanager
 def _temporary_workdir(prefix: str) -> Iterator[str]:
@@ -89,6 +117,23 @@ def _stable_render_kwargs(task_id: str, **kwargs: object) -> dict[str, object]:
 
 
 class _MakeTest(absltest.TestCase):
+    def _family_smoke_tasks(self) -> dict[str, tuple[str, ...]]:
+        from envpool.registration import registry
+
+        tasks = dict(_FAMILY_SMOKE_TASKS)
+        for import_path, prefix in _DYNAMIC_FAMILY_SMOKE_PREFIXES.items():
+            candidates = sorted(
+                task_id
+                for task_id, (registered_import_path, _, _) in (
+                    registry.specs.items()
+                )
+                if registered_import_path == import_path
+                and task_id.startswith(prefix)
+            )
+            self.assertNotEmpty(candidates, import_path)
+            tasks[import_path] = (candidates[0],)
+        return tasks
+
     def check_render_unsupported(self, task_id: str, **kwargs: object) -> None:
         for factory in (envpool.make_gym, envpool.make_gymnasium):
             with self.assertRaisesRegex(RuntimeError, "render not implemented"):
@@ -131,7 +176,19 @@ class _MakeTest(absltest.TestCase):
             raise
 
     def test_version(self) -> None:
-        print(envpool.__version__)
+        config = configparser.ConfigParser()
+        self.assertTrue(config.read(Path(__file__).parents[1] / "setup.cfg"))
+        self.assertEqual(config["metadata"]["version"], envpool.__version__)
+
+    def test_asset_base_path_env_override(self) -> None:
+        from envpool.registration import asset_base_path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.dict(os.environ, {"ENVPOOL_ASSETS_PATH": tmpdir}):
+                self.assertEqual(
+                    asset_base_path("envpool_assets", "atari/roms"),
+                    os.path.abspath(tmpdir),
+                )
 
     def test_public_typing_interface(self) -> None:
         self.assertTrue(Path(envpool.__file__).with_name("py.typed").is_file())
@@ -161,6 +218,26 @@ class _MakeTest(absltest.TestCase):
 
     def test_list_all_envs(self) -> None:
         pprint.pprint(envpool.list_all_envs())
+
+    def test_make_registered_env_families(self) -> None:
+        from envpool.registration import registry
+
+        registered_import_paths = {
+            import_path for import_path, _, _ in registry.specs.values()
+        }
+        smoke_tasks = self._family_smoke_tasks()
+        self.assertEmpty(registered_import_paths - smoke_tasks.keys())
+        self.assertEmpty(smoke_tasks.keys() - registered_import_paths)
+        missing_task_ids = [
+            task_id
+            for task_ids in smoke_tasks.values()
+            for task_id in task_ids
+            if task_id not in registry.specs
+        ]
+        self.assertEmpty(missing_task_ids)
+        for import_path, task_ids in smoke_tasks.items():
+            with self.subTest(import_path=import_path):
+                self.check_step(list(task_ids))
 
     def test_make_atari(self) -> None:
         self.assertRaises(TypeError, envpool.make, "Pong-v5")
@@ -417,6 +494,11 @@ class _MakeTest(absltest.TestCase):
             "WalkerRun-v1",
             "WalkerStand-v1",
             "WalkerWalk-v1",
+        ])
+
+    def test_make_mujoco_playground(self) -> None:
+        self.check_step([
+            "Go1JoystickFlatTerrain-v1",
         ])
 
     def test_render_smoke(self) -> None:

--- a/envpool/mujoco/dmc/registration.py
+++ b/envpool/mujoco/dmc/registration.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 """Mujoco dm_control suite env registration."""
 
-from envpool.registration import register
+from envpool.registration import asset_base_path, register
+
+_DMC_BASE_PATH = asset_base_path("envpool_assets", "mujoco/assets_dmc")
 
 # from suite.BENCHMARKING
 dmc_mujoco_envs = [
@@ -81,4 +83,5 @@ for domain, task, max_episode_steps in dmc_mujoco_envs:
         gymnasium_cls=f"Dmc{domain_name}GymnasiumEnvPool",
         task_name=task,
         max_episode_steps=max_episode_steps,
+        base_path=_DMC_BASE_PATH,
     )

--- a/envpool/mujoco/gym/registration.py
+++ b/envpool/mujoco/gym/registration.py
@@ -15,7 +15,9 @@
 
 from typing import Any
 
-from envpool.registration import register
+from envpool.registration import asset_base_path, register
+
+_GYM_BASE_PATH = asset_base_path("envpool_assets", "mujoco/assets_gym")
 
 gym_mujoco_envs = [
     ("Ant", ("v3", "v4", "v5"), 1000),
@@ -89,5 +91,6 @@ for task, versions, max_episode_steps in gym_mujoco_envs:
             gymnasium_cls=f"Gym{task}GymnasiumEnvPool",
             post_constraint=(version == "v5"),
             max_episode_steps=max_episode_steps,
+            base_path=_GYM_BASE_PATH,
             **extra_args,
         )

--- a/envpool/mujoco/metaworld/registration.py
+++ b/envpool/mujoco/metaworld/registration.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 """MetaWorld v3 Sawyer env registration."""
 
-from envpool.registration import register
+from envpool.registration import asset_base_path, register
+
+_METAWORLD_BASE_PATH = asset_base_path(
+    "envpool_assets", "mujoco/metaworld/assets"
+)
 
 
 def metaworld_public_task_name(task_name: str) -> str:
@@ -96,4 +100,5 @@ for task_name in metaworld_v3_envs:
         gymnasium_cls="MetaWorldGymnasiumEnvPool",
         task_name=task_name,
         max_episode_steps=500,
+        base_path=_METAWORLD_BASE_PATH,
     )

--- a/envpool/mujoco/myosuite/registration.py
+++ b/envpool/mujoco/myosuite/registration.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 """MyoSuite v2.11.6 env registration."""
 
-import os
-
-from envpool.registration import base_path, package_base_path, register
+from envpool.registration import asset_base_path, register
 
 from .tasks import MYOSUITE_TASKS
 
@@ -23,11 +21,8 @@ myosuite_task_ids = [str(task["id"]) for task in MYOSUITE_TASKS]
 myosuite_envpool_task_ids = [
     f"MyoSuite/{task_id}" for task_id in myosuite_task_ids
 ]
-_myosuite_package_assets = os.path.join(
-    package_base_path, "mujoco/myosuite/assets"
-)
-_myosuite_base_path = (
-    package_base_path if os.path.exists(_myosuite_package_assets) else base_path
+_MYOSUITE_BASE_PATH = asset_base_path(
+    "envpool_assets_mujoco_large", "mujoco/myosuite/assets"
 )
 
 for task in MYOSUITE_TASKS:
@@ -41,5 +36,5 @@ for task in MYOSUITE_TASKS:
         gymnasium_cls="MyoSuiteGymnasiumEnvPool",
         task_name=task_id,
         max_episode_steps=task["max_episode_steps"],
-        base_path=_myosuite_base_path,
+        base_path=_MYOSUITE_BASE_PATH,
     )

--- a/envpool/mujoco/myosuite/tasks.py
+++ b/envpool/mujoco/myosuite/tasks.py
@@ -76,6 +76,10 @@ def _read_metadata_json(filename: str) -> Any:
     if __package__:
         resource_roots.append((__package__, ("assets", "metadata")))
     resource_roots.append((
+        "envpool_assets_mujoco_large",
+        ("mujoco", "myosuite", "assets", "metadata"),
+    ))
+    resource_roots.append((
         "envpool_assets",
         ("mujoco", "myosuite", "assets", "metadata"),
     ))

--- a/envpool/mujoco/playground/registration.py
+++ b/envpool/mujoco/playground/registration.py
@@ -13,10 +13,49 @@
 # limitations under the License.
 """MuJoCo Playground env registration."""
 
-from envpool.registration import register
+from envpool.registration import asset_base_path, register
 
 _IMPORT_PATH = "envpool.mujoco.playground"
 _Task = tuple[str, str, int, dict[str, object]]
+
+
+def _playground_base_path(
+    package_name: str,
+    local_asset_path: str,
+) -> str:
+    return asset_base_path(package_name, local_asset_path)
+
+
+_PLAYGROUND_BASE_PATHS = {
+    "humanoid": _playground_base_path(
+        "envpool_assets_mujoco_playground_humanoid",
+        "mujoco/playground/assets/mujoco_playground/_src/locomotion/apollo",
+    ),
+    "nonhumanoid": _playground_base_path(
+        "envpool_assets_mujoco_large",
+        "mujoco/playground/assets/mujoco_playground/_src/locomotion/go1",
+    ),
+}
+
+_PLAYGROUND_ASSET_KEYS = {
+    "PlaygroundAloha": "nonhumanoid",
+    "PlaygroundApollo": "humanoid",
+    "PlaygroundBarkour": "nonhumanoid",
+    "PlaygroundBerkeleyHumanoid": "humanoid",
+    "PlaygroundG1": "humanoid",
+    "PlaygroundGo1": "nonhumanoid",
+    "PlaygroundGo1Getup": "nonhumanoid",
+    "PlaygroundGo1Handstand": "nonhumanoid",
+    "PlaygroundH1": "humanoid",
+    "PlaygroundHand": "nonhumanoid",
+    "PlaygroundOp3": "humanoid",
+    "PlaygroundPanda": "nonhumanoid",
+    "PlaygroundPandaRobotiq": "nonhumanoid",
+    "PlaygroundSpotJoystick": "nonhumanoid",
+    "PlaygroundSpotGetup": "nonhumanoid",
+    "PlaygroundSpotGait": "nonhumanoid",
+    "PlaygroundT1": "humanoid",
+}
 
 _PLAYGROUND_TASKS: tuple[_Task, ...] = (
     ("AlohaHandOver", "PlaygroundAloha", 250, {}),
@@ -145,6 +184,11 @@ _PLAYGROUND_TASKS: tuple[_Task, ...] = (
 PLAYGROUND_ENVS = tuple(task_name for task_name, _, _, _ in _PLAYGROUND_TASKS)
 
 
+def _base_path_for_task(env_cls_prefix: str) -> str:
+    key = _PLAYGROUND_ASSET_KEYS[env_cls_prefix]
+    return _PLAYGROUND_BASE_PATHS[key]
+
+
 def _register_task(
     task_name: str,
     env_cls_prefix: str,
@@ -160,6 +204,7 @@ def _register_task(
         gymnasium_cls=f"{env_cls_prefix}GymnasiumEnvPool",
         task_name=task_name,
         max_episode_steps=max_episode_steps,
+        base_path=_base_path_for_task(env_cls_prefix),
         **kwargs,
     )
 

--- a/envpool/mujoco/robotics/registration.py
+++ b/envpool/mujoco/robotics/registration.py
@@ -15,9 +15,12 @@
 
 from typing import Any
 
-from envpool.registration import register
+from envpool.registration import asset_base_path, register
 
 _IMPORT_PATH = "envpool.mujoco.robotics"
+_ROBOTICS_BASE_PATH = asset_base_path(
+    "envpool_assets", "mujoco/robotics/assets"
+)
 _ROBOTICS_ENV_CLASSES = {
     "Fetch": (
         "GymnasiumRoboticsFetchEnvSpec",
@@ -365,6 +368,7 @@ def _register_robotics_env(
         spec_cls=spec_cls,
         dm_cls=dm_cls,
         gymnasium_cls=gymnasium_cls,
+        base_path=_ROBOTICS_BASE_PATH,
         **kwargs,
     )
 

--- a/envpool/procgen/registration.py
+++ b/envpool/procgen/registration.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 """Procgen env registration."""
 
-from envpool.registration import register
+from envpool.registration import asset_base_path, register
+
+_PROCGEN_BASE_PATH = asset_base_path("envpool_assets", "procgen/assets")
 
 # 16 games in Procgen
 # https://github.com/openai/procgen/blob/0.10.7/procgen/src/game.cpp#L56-L66
@@ -56,4 +58,5 @@ for env_name, timeout, dist_mode in procgen_game_config:
             env_name=env_name,
             distribution_mode=dist_value,
             max_episode_steps=timeout,
+            base_path=_PROCGEN_BASE_PATH,
         )

--- a/envpool/registration.py
+++ b/envpool/registration.py
@@ -61,6 +61,17 @@ package_base_path = os.path.abspath(os.path.dirname(__file__))
 base_path = _asset_base_path()
 
 
+def asset_base_path(package_name: str, local_asset_path: str) -> str:
+    """Return the asset root for one split asset package."""
+    override = os.environ.get("ENVPOOL_ASSETS_PATH")
+    if override:
+        return os.path.abspath(override)
+    local_path = os.path.join(package_base_path, local_asset_path)
+    if os.path.exists(local_path):
+        return package_base_path
+    return _package_dir(package_name) or base_path
+
+
 class EnvRegistry:
     """A collection of available envs."""
 

--- a/envpool/vizdoom/registration.py
+++ b/envpool/vizdoom/registration.py
@@ -15,9 +15,10 @@
 
 import os
 
-from envpool.registration import base_path, package_base_path, register
+from envpool.registration import asset_base_path, package_base_path, register
 
-maps_path = os.path.join(base_path, "vizdoom", "maps")
+_VIZDOOM_BASE_PATH = asset_base_path("envpool_assets", "vizdoom/maps")
+maps_path = os.path.join(_VIZDOOM_BASE_PATH, "vizdoom", "maps")
 
 
 def _vizdoom_game_list() -> list[str]:
@@ -48,4 +49,5 @@ for game in _vizdoom_game_list() + ["vizdoom_custom"]:
         vzd_path=os.path.join(package_base_path, "vizdoom", "bin", "vizdoom"),
         wad_path=wad_path,
         max_episode_steps=525,
+        base_path=_VIZDOOM_BASE_PATH,
     )

--- a/scripts/release_installed_wheel_smoke.py
+++ b/scripts/release_installed_wheel_smoke.py
@@ -4,10 +4,120 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 from importlib.metadata import version
 from pathlib import Path
 
 from packaging.version import Version
+
+_ASSET_PACKAGES = {
+    "envpool-assets": (
+        "envpool_assets",
+        [
+            "atari/roms/pong.bin",
+            "gfootball/assets/data",
+            "mujoco/assets_dmc/cartpole.xml",
+            "mujoco/assets_gym/ant.xml",
+            "mujoco/metaworld/assets/objects/assets/drawer.xml",
+            "mujoco/robotics/assets/fetch/reach.xml",
+            "procgen/assets/platformer/playerBlue_dead.png",
+            "vizdoom/bin/freedoom2.wad",
+            "vizdoom/maps/basic.wad",
+        ],
+    ),
+    "envpool-assets-mujoco-large": (
+        "envpool_assets_mujoco_large",
+        [
+            "mujoco/myosuite/assets/myosuite/envs/myo/assets/hand/myohand_pose.xml",
+            "mujoco/playground/assets/mujoco_menagerie/google_barkour_vb/scene_mjx.xml",
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "locomotion/go1/xmls/scene_mjx_feetonly_flat_terrain.xml"
+            ),
+            (
+                "mujoco/playground/assets/mujoco_menagerie/"
+                "unitree_go1/assets/trunk.stl"
+            ),
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "locomotion/spot/xmls/scene_mjx_feetonly_flat_terrain.xml"
+            ),
+            "mujoco/playground/assets/mujoco_menagerie/boston_dynamics_spot/spot.xml",
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "manipulation/aero_hand/xmls/scene_mjx_cube.xml"
+            ),
+            (
+                "mujoco/playground/assets/mujoco_menagerie/"
+                "tetheria_aero_hand_open/right_hand.xml"
+            ),
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "manipulation/aloha/xmls/mjx_hand_over.xml"
+            ),
+            "mujoco/playground/assets/mujoco_menagerie/aloha/aloha.xml",
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "manipulation/franka_emika_panda/xmls/mjx_single_cube.xml"
+            ),
+            "mujoco/playground/assets/mujoco_menagerie/franka_emika_panda/panda.xml",
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "manipulation/franka_emika_panda_robotiq/xmls/"
+                "scene_panda_robotiq_cube.xml"
+            ),
+            "mujoco/playground/assets/mujoco_menagerie/franka_emika_panda/panda.xml",
+            "mujoco/playground/assets/mujoco_menagerie/robotiq_2f85_v4/mjx_2f85.xml",
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "manipulation/leap_hand/xmls/scene_mjx_cube.xml"
+            ),
+            "mujoco/playground/assets/mujoco_menagerie/leap_hand/right_hand.xml",
+        ],
+    ),
+    "envpool-assets-mujoco-playground-humanoid": (
+        "envpool_assets_mujoco_playground_humanoid",
+        [
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "locomotion/apollo/xmls/scene_mjx_feetonly_flat_terrain.xml"
+            ),
+            (
+                "mujoco/playground/assets/mujoco_menagerie/"
+                "apptronik_apollo/apptronik_apollo.xml"
+            ),
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "locomotion/berkeley_humanoid/xmls/"
+                "scene_mjx_feetonly_flat_terrain.xml"
+            ),
+            (
+                "mujoco/playground/assets/mujoco_menagerie/"
+                "berkeley_humanoid/berkeley_humanoid.xml"
+            ),
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "locomotion/g1/xmls/scene_mjx_feetonly_flat_terrain.xml"
+            ),
+            "mujoco/playground/assets/mujoco_menagerie/unitree_g1/g1_mjx.xml",
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "locomotion/h1/xmls/scene_mjx_feetonly.xml"
+            ),
+            "mujoco/playground/assets/mujoco_menagerie/unitree_h1/h1.xml",
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "locomotion/op3/xmls/scene_mjx_feetonly.xml"
+            ),
+            "mujoco/playground/assets/mujoco_menagerie/robotis_op3/op3.xml",
+            (
+                "mujoco/playground/assets/mujoco_playground/_src/"
+                "locomotion/t1/xmls/scene_mjx_feetonly_flat_terrain.xml"
+            ),
+            "mujoco/playground/assets/mujoco_menagerie/booster_t1/t1.xml",
+        ],
+    ),
+}
 
 
 def _parse_args() -> argparse.Namespace:
@@ -29,53 +139,47 @@ def _is_relative_to(path: Path, parent: Path) -> bool:
     return True
 
 
+def _check_asset_package(
+    distribution: str, module_name: str, rels: list[str]
+) -> None:
+    asset_version = Version(version(distribution))
+    if not Version("0.3.0") <= asset_version < Version("0.4.0"):
+        raise RuntimeError(
+            f"unexpected {distribution} version: {asset_version}"
+        )
+    module = importlib.import_module(module_name)
+    asset_root = Path(module.asset_path()).resolve()
+    missing = [
+        asset_root / rel for rel in rels if not (asset_root / rel).exists()
+    ]
+    if missing:
+        raise RuntimeError(f"{distribution} missing required files: {missing}")
+    print(f"{distribution} {asset_version} installed at {asset_root}")
+
+
 def main() -> None:
     """Check installed EnvPool and envpool-assets package wiring."""
     args = _parse_args()
     source_root = args.source_root.resolve()
 
-    import envpool_assets
-
     import envpool
-    from envpool.registration import base_path, package_base_path
+    from envpool.registration import package_base_path
 
     envpool_package = Path(envpool.__file__).resolve().parent
-    assets_package = Path(envpool_assets.asset_path()).resolve()
 
     if _is_relative_to(envpool_package, source_root):
         raise RuntimeError(
             f"imported EnvPool from source tree: {envpool_package}"
         )
 
-    asset_version = Version(version("envpool-assets"))
-    if not Version("0.2.0") <= asset_version < Version("0.3.0"):
-        raise RuntimeError(
-            f"unexpected envpool-assets version: {asset_version}"
-        )
-
-    if Path(base_path).resolve() != assets_package:
-        raise RuntimeError(
-            f"EnvPool asset base_path is {base_path}, expected {assets_package}"
-        )
     if Path(package_base_path).resolve() != envpool_package:
         raise RuntimeError(
             "EnvPool package_base_path is "
             f"{package_base_path}, expected {envpool_package}"
         )
 
-    required_assets = [
-        assets_package / "atari/roms/pong.bin",
-        assets_package / "gfootball/assets/data",
-        assets_package / "mujoco/assets_dmc/cartpole.xml",
-        assets_package
-        / "mujoco/myosuite/assets/myosuite/envs/myo/assets/hand/myohand_pose.xml",
-        assets_package / "procgen/assets/platformer/playerBlue_dead.png",
-        assets_package / "vizdoom/bin/freedoom2.wad",
-        assets_package / "vizdoom/maps/basic.wad",
-    ]
-    missing = [path for path in required_assets if not path.exists()]
-    if missing:
-        raise RuntimeError(f"envpool-assets missing required files: {missing}")
+    for distribution, (module_name, rels) in _ASSET_PACKAGES.items():
+        _check_asset_package(distribution, module_name, rels)
 
     required_package_files = [
         envpool_package / "vizdoom/bin/vizdoom",
@@ -86,7 +190,6 @@ def main() -> None:
         raise RuntimeError(f"envpool wheel missing required files: {missing}")
 
     print(f"envpool installed at {envpool_package}")
-    print(f"envpool-assets {asset_version} installed at {assets_package}")
 
 
 if __name__ == "__main__":

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = envpool
-version = 1.2.4
+version = 1.2.5
 author = "EnvPool Contributors"
 author_email = "sail@sea.com"
 description = "C++-based high-performance parallel environment execution engine (vectorized env) for general RL environments."
@@ -26,7 +26,9 @@ packages = find:
 python_requires = >=3.11
 install_requires =
     dm-env>=1.4
-    envpool-assets>=0.2.0,<0.3.0
+    envpool-assets>=0.3.0,<0.4.0
+    envpool-assets-mujoco-large>=0.3.0,<0.4.0
+    envpool-assets-mujoco-playground-humanoid>=0.3.0,<0.4.0
     glfw>=2.10.0
     gymnasium>=0.26
     matplotlib>=3.5


### PR DESCRIPTION
## Description

This bumps EnvPool to 1.2.5 and updates release asset resolution for the published `envpool-assets==0.3.0` split packages:

- `envpool-assets`
- `envpool-assets-mujoco-large`
- `envpool-assets-mujoco-playground-humanoid`

The registration modules now resolve assets from the owning split asset package, while keeping the existing local-package / `ENVPOOL_ASSETS_PATH` fallback path. The release smoke check also verifies representative files from each split asset wheel.

## Motivation and Context

This fixes missing MuJoCo Playground assets in the 1.2.4 release path, where installed wheels could register Playground envs but fail at runtime because the XML assets were not present in `envpool-assets`.

Fixes #413.

- [x] I have raised an issue to propose this change ([required](https://envpool.readthedocs.io/en/latest/pages/contributing.html) for new features and bug fixes)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds core functionality)
- [ ] New environment (non-breaking change which adds 3rd-party environment)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (update in the documentation)
- [ ] Example (update in the folder of example)

## Implemented Tasks

- [x] Bump EnvPool version to 1.2.5 and require asset wheels `>=0.3.0,<0.4.0`
- [x] Route base, MyoSuite, and MuJoCo Playground registrations to the correct split asset packages
- [x] Extend release smoke checks to cover the split asset packages and a Playground env

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply.
If you are unsure about any of these, don't hesitate to ask. We are here to help!

- [x] I have read the [CONTRIBUTION](https://envpool.readthedocs.io/en/latest/pages/contributing.html) guide (**required**)
- [ ] My change requires a change to the documentation.
- [x] I have updated the tests accordingly (*required for a bug fix or a new feature*).
- [ ] I have updated the documentation accordingly.
- [ ] I have reformatted the code using `make format` (**required**)
- [ ] I have checked the code using `make lint` (**required**)
- [ ] I have ensured `make bazel-test` pass. (**required**)

Validation run:

- `python3 -m py_compile envpool/registration.py envpool/atari/registration.py envpool/gfootball/registration.py envpool/procgen/registration.py envpool/vizdoom/registration.py envpool/mujoco/dmc/registration.py envpool/mujoco/gym/registration.py envpool/mujoco/metaworld/registration.py envpool/mujoco/myosuite/registration.py envpool/mujoco/playground/registration.py envpool/mujoco/robotics/registration.py scripts/release_installed_wheel_smoke.py`
- `git diff --check origin/main...HEAD`
- `envpool-assets` GitHub Actions run `26133010572` built and published all three `0.3.0` asset wheels successfully
