### PR TITLE
Upload release wheels to GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,6 +279,9 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs: [release-linux, release-macos, release-windows]
+    permissions:
+      actions: read
+      contents: write
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -293,3 +296,14 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true
+      - name: Create GitHub release and upload wheels
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 || \
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "${GITHUB_REF_NAME}" \
+              --generate-notes \
+              --verify-tag
+          gh release upload "${GITHUB_REF_NAME}" dist/*.whl --clobber


### PR DESCRIPTION
## Summary
- add a post-PyPI publish step that creates the GitHub release when needed
- upload built wheels to the release page with --clobber so reruns are idempotent
- enable skip-existing for PyPI publish reruns after a partial release

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'
- git diff --check
- manually uploaded the v1.2.5 wheels from run 26184878430 to the release page and verified 16 assets