### PR TITLE
fix(jumanji): prevent IndexError in routing render when no valid nodes

### DIFF
--- a/envpool/jumanji/_official_render/routing.py
+++ b/envpool/jumanji/_official_render/routing.py
@@ -653,7 +653,10 @@ class MMSTViewer(MatplotlibViewer):
 
         for agent in range(self.num_agents):
             conn_group = connected_nodes[agent]
-            len_conn = np.where(conn_group != -1)[0][-1]
+            valid_indices = np.where(conn_group != -1)[0]
+            if len(valid_indices) == 0:
+                continue
+            len_conn = valid_indices[-1]
             for i in range(len_conn):
                 key = edge_id(conn_group[i], conn_group[i + 1])
                 edges[key] = [


### PR DESCRIPTION
## Summary

Fix an IndexError in the Jumanji routing renderer's `build_edges()` method that crashes when an agent has no valid connected nodes.

## Root Cause

In `envpool/jumanji/_official_render/routing.py` line 656:

```python
len_conn = np.where(conn_group != -1)[0][-1]
```

When `conn_group` contains only `-1` values (no valid connected nodes for an agent), `np.where(conn_group != -1)[0]` returns an empty array. Accessing `[-1]` on an empty array raises `IndexError`.

## Fix

Add a guard to check if there are valid indices before proceeding:

```python
valid_indices = np.where(conn_group != -1)[0]
if len(valid_indices) == 0:
    continue
len_conn = valid_indices[-1]
```

## Test plan

- [x] Verify rendering works when all agents have valid connected nodes
- [x] Verify no crash when an agent has no valid connected nodes