### PR TITLE
fix(setup): correct has_ext_modules method parameter name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class BinaryDistribution(Distribution):
         """Return `False` because EnvPool ships extension modules."""
         return False
 
-    def has_ext_modules(foo) -> bool:
+    def has_ext_modules(self) -> bool:
         """Report that EnvPool has extension modules."""
         return True
 


### PR DESCRIPTION
## Summary

Fix the  method parameter name from  to  in  class.

## Root Cause

In  line 33:


The parameter should be  to follow Python method conventions. This is inconsistent with  defined just above it on line 29, and with the parent class .

While functionally equivalent (Python doesn't enforce parameter naming), this:
- Confuses linters and type checkers (pylint R0201, mypy)
- Is inconsistent with the rest of the codebase
- Makes the code harder to read

## Test plan

- [x] Verify  still works
- [x] Verify wheel build process is unaffected