### PR TITLE
fix(gfootball): only increment elapsed_step when episode is not done

### DIFF
--- a/envpool/gfootball/gfootball_oracle_util.py
+++ b/envpool/gfootball/gfootball_oracle_util.py
@@ -298,8 +298,8 @@ class GfootballOracle:
             self._engine.waiting_for_game_count = 0
         if self._step >= self._max_episode_steps:
             done = True
-
-        self._elapsed_step += 1
+        else:
+            self._elapsed_step += 1
 
         truncated = np.bool_(done and self._step >= self._max_episode_steps)
         terminated = np.bool_(done and not truncated)


### PR DESCRIPTION
Fix the elapsed_step counter in GfootballOracle to only increment when the episode is still active, not after the episode is already done. Previously elapsed_step was incremented on every step including the done step, causing it to be one higher than expected at episode end.