### PR TITLE
fix: add bounds check for action index in AtariEnv::Step

### DIFF
--- a/envpool/atari/atari_env.h
+++ b/envpool/atari/atari_env.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <deque>
+#include <iostream>
 #include <memory>
 #include <random>
 #include <sstream>
@@ -203,6 +204,12 @@ class AtariEnv : public Env<AtariEnvSpec>, public RenderableEnv {
     float reward = 0.0;
     done_ = false;
     int act = action["action"_];
+    if (act < 0 || act >= static_cast<int>(action_set_.size())) {
+      std::cerr << "AtariEnv::Step: action " << act
+                << " is out of range [0, " << action_set_.size()
+                << "), clamping to valid range." << std::endl;
+      act = std::clamp(act, 0, static_cast<int>(action_set_.size()) - 1);
+    }
     int skip_id = frame_skip_;
     int pooled_frame_count = std::min(frame_skip_, 2);
     for (; skip_id > 0 && !done_; --skip_id) {


### PR DESCRIPTION
## Summary
- Add runtime bounds checking for the action index in `AtariEnv::Step()` to prevent undefined behavior from out-of-range actions

## Problem

In `atari_env.h`, the action index `act` from `action["action"_]` is used directly as an index into `action_set_` without any bounds validation:

```cpp
int act = action["action"_];
// ...
reward += env_->act(action_set_[act]);  // UB if act is out of range
```

If `act` is negative or >= `action_set_.size()`, this results in undefined behavior via out-of-bounds vector access. While the Python binding normally constrains action values, a malformed action array (e.g., from a buggy policy or adversarial input) would trigger UB.

## Changes
- Added bounds check that clamps `act` to `[0, action_set_.size())` 
- Logs a warning to stderr when an invalid action is detected
- Added `#include <iostream>` for the warning message

## Test plan
- [ ] Run existing Atari test suite to confirm no regressions
- [ ] Verify that a valid action (e.g., 0-3 for Pong) still works normally
- [ ] Verify that an out-of-range action is clamped and produces a warning instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)