### PR TITLE
fix(core): avoid KeyError when batch_size is given without num_envs

### DIFF
--- a/envpool/make_test.py
+++ b/envpool/make_test.py
@@ -282,6 +282,18 @@ class _MakeTest(absltest.TestCase):
             env_gym.close()
             env_gymnasium.close()
 
+    def test_make_batch_size_without_num_envs(self) -> None:
+        # Regression: passing batch_size without num_envs used to raise
+        # KeyError on the bare kwargs["num_envs"] subscript in
+        # EnvRegistry._make_env_spec. batch_size=0 means "default to
+        # num_envs" (see core/env_spec.h) and must be accepted; an
+        # out-of-range batch_size must raise AssertionError, not KeyError.
+        env = envpool.make_gymnasium("CartPole-v1", batch_size=0)
+        env.close()
+        self.assertRaises(
+            AssertionError, envpool.make_gymnasium, "CartPole-v1", batch_size=2
+        )
+
     def test_make_vizdoom(self) -> None:
         try:
             with _temporary_workdir(prefix="envpool-vizdoom-smoke-"):

--- a/envpool/registration.py
+++ b/envpool/registration.py
@@ -235,7 +235,7 @@ class EnvRegistry:
         if "num_envs" in kwargs:
             assert kwargs["num_envs"] >= 1
         if "batch_size" in kwargs:
-            assert 0 <= kwargs["batch_size"] <= kwargs["num_envs"]
+            assert 0 <= kwargs["batch_size"] <= kwargs.get("num_envs", 1)
         if "max_num_players" in kwargs:
             assert 1 <= kwargs["max_num_players"]
 


### PR DESCRIPTION
## Problem

`envpool.make(...)` raises a `KeyError: 'num_envs'` whenever `batch_size` is supplied without an explicit `num_envs`.

In `EnvRegistry._make_env_spec` (`envpool/registration.py`), the `batch_size` validation indexed `kwargs["num_envs"]` directly:

```python
if "batch_size" in kwargs:
    assert 0 <= kwargs["batch_size"] <= kwargs["num_envs"]   # KeyError
```

…while the two seed-normalization blocks immediately above already use the safe form `kwargs.get("num_envs", 1)`. `num_envs` is never injected into `kwargs` — it only appears there if the user passes it — so the bare subscript crashes before `gen_config` is ever reached.

This is reachable through the documented public API:
- `batch_size` is a first-class `make()` argument ([README](../blob/main/README.md) / `docs/content/python_interface.rst`).
- `batch_size=0` is a **valid** value meaning "default to `num_envs`" (`core/env_spec.h` turns `batch_size == 0` into `num_envs`).

## Reproduction

```python
import envpool
envpool.make("Pong-v5", env_type="gymnasium", batch_size=0)
# KeyError: 'num_envs'   <- before this PR
```

## Fix

Use the same default as the neighboring validation (one-line change, matches the existing `kwargs.get("num_envs", 1)` pattern):

```python
if "batch_size" in kwargs:
    assert 0 <= kwargs["batch_size"] <= kwargs.get("num_envs", 1)
```

Behavior after the fix:

| call | before | after |
| --- | --- | --- |
| `batch_size=0` (no `num_envs`) | `KeyError` ✗ | **OK** (defaults to `num_envs`) |
| `batch_size=1` (no `num_envs`) | `KeyError` ✗ | **OK** |
| `batch_size=2` (no `num_envs`, out of range) | `KeyError` ✗ | `AssertionError` (correctly rejected) |
| `num_envs=64, batch_size=16` (README usage) | OK | OK (unchanged) |

The documented multi-env usage is unaffected; only the spurious `KeyError` is removed and out-of-range values are now rejected with a proper `AssertionError`.

## Test

Added `test_make_batch_size_without_num_envs` to `envpool/make_test.py`, which fails (`KeyError`) before the fix and passes after.

## Validation

```
make ruff py-format   # pass
make mypy             # changed files clean (under py311 target)
```