### PR TITLE
[core] Optimize non-owning Array views

### DIFF
--- a/envpool/core/BUILD
+++ b/envpool/core/BUILD
@@ -50,6 +50,15 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "array_test",
+    srcs = ["array_test.cc"],
+    deps = [
+        ":array",
+        "@com_google_googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "dict",
     hdrs = ["dict.h"],

--- a/envpool/core/array.h
+++ b/envpool/core/array.h
@@ -37,6 +37,16 @@ class Array {
   std::vector<std::size_t> shape_;
   std::shared_ptr<char> ptr_;
 
+  // An aliasing shared_ptr with an empty owner stores ptr without allocating a
+  // control block. It remains non-owning, matching existing view semantics.
+  template <class Shape>
+  Array(char* ptr, Shape&& shape, std::size_t element_size)  // NOLINT
+      : size(Prod(shape.data(), shape.size())),
+        ndim(shape.size()),
+        element_size(element_size),
+        shape_(std::forward<Shape>(shape)),
+        ptr_(std::shared_ptr<char>(), ptr) {}
+
   template <class Shape, class Deleter>
   Array(char* ptr, Shape&& shape, std::size_t element_size,  // NOLINT
         Deleter&& deleter)
@@ -59,8 +69,7 @@ class Array {
 
   /**
    * Constructor an `Array` of shape defined by `spec`, with `data` as pointer
-   * to its raw memory. With an empty deleter, which means Array does not own
-   * the memory.
+   * to its raw memory. Array does not own the memory.
    */
   template <class Deleter>
   Array(const ShapeSpec& spec, char* data, Deleter&& deleter)  // NOLINT
@@ -68,20 +77,22 @@ class Array {
               std::forward<Deleter>(deleter)) {}
 
   Array(const ShapeSpec& spec, char* data)
-      : Array(data, spec.Shape(), spec.element_size, [](char* /*unused*/) {}) {}
+      : Array(data, spec.Shape(), spec.element_size) {}
 
   /**
    * Constructor an `Array` of shape defined by `spec`. This constructor
    * allocates and owns the memory.
    */
-  explicit Array(const ShapeSpec& spec)
-      : Array(spec, nullptr, [](char* /*unused*/) {}) {
+  explicit Array(const ShapeSpec& spec) : Array(spec, nullptr) {
     auto buffer = std::make_shared<std::vector<char>>(size * element_size);
     ptr_ = std::shared_ptr<char>(buffer, buffer->data());
   }
 
   /**
    * Take multidimensional index into the Array.
+   *
+   * The returned view does not extend this Array's storage lifetime.
+   * Callers must keep the backing Array alive while using it.
    */
   template <typename... Index>
   Array operator()(Index... index) const {
@@ -95,7 +106,7 @@ class Array {
     return Array(
         ptr_.get() + offset * element_size,
         std::vector<std::size_t>(shape_.begin() + num_index, shape_.end()),
-        element_size, [](char* /*unused*/) {});
+        element_size);
   }
 
   /**
@@ -105,6 +116,9 @@ class Array {
 
   /**
    * Take a slice at the first axis of the Array.
+   *
+   * The returned view does not extend this Array's storage lifetime.
+   * Callers must keep the backing Array alive while using it.
    */
   [[nodiscard]] Array Slice(std::size_t start, std::size_t end) const {
     DCHECK_GT(ndim, (std::size_t)0);
@@ -117,7 +131,7 @@ class Array {
       offset = start * size / shape_[0];
     }
     return {ptr_.get() + offset * element_size, std::move(new_shape),
-            element_size, [](char* p) {}};
+            element_size};
   }
 
   /**

--- a/envpool/core/array_test.cc
+++ b/envpool/core/array_test.cc
@@ -1,0 +1,104 @@
+// Copyright 2026 Garena Online Private Limited
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "envpool/core/array.h"
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "envpool/core/spec.h"
+
+TEST(ArrayTest, ViewsPreserveHighDimensionalShapesAndData) {
+  ShapeSpec spec(sizeof(int), {2, 3, 4, 5, 6});
+  Array array(spec);
+
+  auto view = array(1, 2);
+  EXPECT_EQ(view.Shape(), std::vector<std::size_t>({4, 5, 6}));
+  view(3, 4, 5) = 17;
+  EXPECT_EQ(*reinterpret_cast<int*>(array(1, 2, 3, 4, 5).Data()), 17);
+
+  auto slice = array.Slice(1, 2);
+  EXPECT_EQ(slice.Shape(), std::vector<std::size_t>({1, 3, 4, 5, 6}));
+  slice(0, 2, 3, 4, 5) = 23;
+  EXPECT_EQ(*reinterpret_cast<int*>(array(1, 2, 3, 4, 5).Data()), 23);
+}
+
+TEST(ArrayTest, TruncateAndSharedPtrKeepOwnedStorageAlive) {
+  ShapeSpec spec(sizeof(int), {4});
+  int delete_count = 0;
+  std::shared_ptr<char> shared;
+
+  {
+    Array truncated;
+    {
+      auto* data = new char[4 * sizeof(int)];
+      Array parent(spec, data, [&delete_count](char* ptr) {
+        ++delete_count;
+        delete[] ptr;
+      });
+      truncated = parent.Truncate(2);
+      shared = truncated.SharedPtr();
+      EXPECT_EQ(shared.get(), truncated.Data());
+    }
+    EXPECT_EQ(delete_count, 0);
+  }
+
+  EXPECT_EQ(delete_count, 0);
+  shared.reset();
+  EXPECT_EQ(delete_count, 1);
+}
+
+TEST(ArrayTest, SharedPtrPreservesNonOwningDataPointer) {
+  ShapeSpec spec(sizeof(int), {2});
+  int data[2] = {};
+  Array array(spec, reinterpret_cast<char*>(data));
+
+  auto shared = array.SharedPtr();
+  EXPECT_EQ(shared.get(), reinterpret_cast<char*>(data));
+}
+
+TEST(ArrayTest, ViewsDoNotExtendBackingStorageLifetime) {
+  ShapeSpec spec(sizeof(int), {2, 2});
+  int delete_count = 0;
+
+  {
+    Array indexed_view;
+    Array slice;
+    {
+      auto* data = new char[4 * sizeof(int)];
+      Array parent(spec, data, [&delete_count](char* ptr) {
+        ++delete_count;
+        delete[] ptr;
+      });
+      indexed_view = parent(1);
+      slice = parent.Slice(0, 1);
+    }
+    EXPECT_EQ(delete_count, 1);
+  }
+
+  EXPECT_EQ(delete_count, 1);
+}
+
+TEST(ArrayTest, TypedTruncateSharesData) {
+  Spec<int> spec(std::vector<int>({4}));
+  TArray<int> array(spec);
+
+  auto truncated = array.Truncate(2);
+  truncated[1] = 31;
+
+  EXPECT_EQ(static_cast<int>(array[1]), 31);
+}


### PR DESCRIPTION
## Summary

Discussion #426 identified a hot allocation in non-owning `Array` views:
constructing a `shared_ptr` with a no-op deleter allocates a control block for
each indexing or slice operation. This changes only the non-owning path to use
an aliasing `shared_ptr` with an empty owner, which preserves the raw pointer
without allocating a control block.

Owning arrays, custom deleters, `Truncate()`, `SharedPtr()`, the existing shape
storage, and the public `Shape()` API remain unchanged. The view lifetime
contract is now documented explicitly: `operator()` and `Slice()` do not keep
the backing storage alive.

Key review points:
- `envpool/core/array.h`: uses the empty-owner aliasing constructor for
  non-owning arrays, indexing views, and slices while retaining the existing
  owning/custom-deleter paths.
- `envpool/core/array_test.cc`: covers high-dimensional view shape/data,
  owned `Truncate()` and `SharedPtr()` lifetime, non-owning pointers, and the
  non-owning lifetime contract for indexed/sliced views.
- `envpool/core/BUILD`: registers the focused `array_test` target.

## Test Plan

### Automated
- `cpplint envpool/core/array.h envpool/core/array_test.cc`: passed.
- `clang-format --style=file --dry-run --Werror envpool/core/array.h envpool/core/array_test.cc`: passed.
- `buildifier -mode=check envpool/core/BUILD`: passed.
- `git diff --check`: passed.
- `bazel test --test_output=errors //envpool/core:array_test //envpool/core:state_buffer_test //envpool/core:action_buffer_queue_test //envpool/toy_text:toy_text_test`: passed on macOS arm64, Linux x86_64, and native Linux aarch64.
- `bazel test --test_output=errors //envpool/core:array_test //envpool/core:state_buffer_test //envpool/core:state_buffer_queue_test //envpool/core:action_buffer_queue_test //envpool/toy_text:toy_text_test`: passed on Windows x86_64.
- `bazel test --test_output=errors --copt=-fsanitize=address --linkopt=-fsanitize=address //envpool/core:array_test`: passed on macOS arm64.
